### PR TITLE
Make input_script a positional arg for benchit

### DIFF
--- a/docs/benchit_user_guide.md
+++ b/docs/benchit_user_guide.md
@@ -234,13 +234,14 @@ You can see the options available for any command by running `benchit COMMAND --
 
 The `benchmark` command supports the arguments from [Devices and Runtimes](#devices-and-runtimes), as well as:
 
+- `input_script` Name of the script (.py) file, within the search directory, to be benchmarked.
+  - You can leverage model hashes (see [Model Hashes](#model-hashes)) at build or benchmarking time in the following manner:
+    - `benchit benchmark example.py::hash_0` will only benchmark the model corresponding to `hash_0`.
+    - You can also supply multiple hashes, for example `benchit benchmark example.py::hash_0,hash_1` will benchmark the models corresponding to both `hash_0` and `hash_1`.
+  - Not available as an API argument.
 - `-s SEARCH_DIR, --search-dir SEARCH_DIR` Path to a directory (defaults to the command line command line location), which serves as the search path for input scripts
   - Not available as an API argument.
-- `-i INPUT_SCRIPTS [INPUT_SCRIPTS ...], --input-scripts INPUT_SCRIPTS [INPUT_SCRIPTS ...]` Name(s) of script (.py) files, within the search directory, to be built (defaults to ["all"], which uses all script files).
-  - You can leverage model hashes (see [Model Hashes](#model-hashes)) at build or benchmarking time in the following manner:
-    - `benchit benchmark -i example.py::hash_0` will only benchmark the model corresponding to `hash_0`.
-    - You can also supply multiple hashes, for example `benchit benchmark -i example.py::hash_0,hash_1` will benchmark the models corresponding to both `hash_0` and `hash_1`.
-  - Not available as an API argument.
+- `--all` Benchmark all models within all script (.py) files in the search directory.
 - `--use-slurm` Execute the build(s) on Slurm instead of using local compute resources
   - Not available as an API argument.
 - `--lean-cache` Delete all build artifacts except for log files after the build

--- a/src/mlagility/cli/benchmark.py
+++ b/src/mlagility/cli/benchmark.py
@@ -44,25 +44,23 @@ def main(args):
     available_scripts = filesystem.get_available_scripts(args.search_dir)
 
     # Filter based on the model names provided by the user
-    if args.input_scripts == ["all"]:
+    if args.benchmark_all:
         scripts = [
             os.path.join(args.search_dir, script) for script in available_scripts
         ]
     else:
-        scripts = []
-        for user_script in args.input_scripts:
-            user_script_path = os.path.join(args.search_dir, user_script)
+        user_script_path = os.path.join(args.search_dir, args.input_script)
 
-            # Ignore everything after the ':' symbol, if there is one
-            clean_user_script_path = user_script_path.split(":")[0]
+        # Ignore everything after the ':' symbol, if there is one
+        clean_user_script_path = user_script_path.split(":")[0]
 
-            # Validate that the script exists
-            if os.path.exists(clean_user_script_path):
-                scripts.append(user_script_path)
-            else:
-                raise exceptions.GroqitArgError(
-                    f"Script could not be found: {user_script_path}"
-                )
+        # Validate that the script exists
+        if os.path.exists(clean_user_script_path):
+            scripts = [user_script_path]
+        else:
+            raise exceptions.GroqitArgError(
+                f"Script could not be found: {user_script_path}"
+            )
 
     # Decode benchit args into TracerArgs flags
     if args.analyze_only:

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -86,15 +86,17 @@ def main():
     )
 
     benchmark_parser.add_argument(
-        "-i",
-        "--input-scripts",
-        nargs="+",
-        dest="input_scripts",
-        help="Name(s) of script (.py) files, within the search directory, "
-        "to be benchmarked (defaults to "
-        '["all"], which uses all script files)',
-        required=False,
-        default=["all"],
+        "input_script",
+        nargs="?",
+        help="Name of the script (.py) file, within the search directory, "
+        "to be benchmarked",
+    )
+
+    benchmark_parser.add_argument(
+        "--all",
+        dest="benchmark_all",
+        help="Benchmark all models within all scripts in the search directory",
+        action="store_true",
     )
 
     benchmark_parser.add_argument(
@@ -412,7 +414,6 @@ def main():
     if len(sys.argv) > 1:
         script_name, _ = benchmark_command.decode_script_name(sys.argv[1])
         if sys.argv[1] not in subparsers.choices.keys() and script_name.endswith(".py"):
-            sys.argv.insert(1, "-i")
             sys.argv.insert(1, "benchmark")
 
     args = parser.parse_args()

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -85,14 +85,16 @@ def main():
         default=os.getcwd(),
     )
 
-    benchmark_parser.add_argument(
+    benchmark_group = benchmark_parser.add_mutually_exclusive_group(required=True)
+
+    benchmark_group.add_argument(
         "input_script",
         nargs="?",
         help="Name of the script (.py) file, within the search directory, "
         "to be benchmarked",
     )
 
-    benchmark_parser.add_argument(
+    benchmark_group.add_argument(
         "--all",
         dest="benchmark_all",
         help="Benchmark all models within all scripts in the search directory",

--- a/test/cli.py
+++ b/test/cli.py
@@ -126,7 +126,6 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
-            "-i",
             os.path.join(corpus_dir, test_script),
             "--build-only",
         ]
@@ -143,10 +142,9 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            test_script,
             "-s",
             corpus_dir,
-            "-i",
-            test_script,
             "--build-only",
         ]
         with patch.object(sys, "argv", testargs):
@@ -165,6 +163,7 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            "--all",
             "-s",
             corpus_dir,
             "--build-only",
@@ -186,6 +185,7 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            "--all",
             "-s",
             corpus_dir,
             "--build-only",
@@ -223,6 +223,7 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            "--all",
             "-s",
             corpus_dir,
             "--build-only",
@@ -255,6 +256,7 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            "--all",
             "-s",
             corpus_dir,
             "--build-only",
@@ -310,6 +312,7 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            "--all",
             "-s",
             corpus_dir,
             "--build-only",
@@ -364,10 +367,9 @@ class Testing(unittest.TestCase):
         testargs = [
             "benchit",
             "benchmark",
+            test_script,
             "-s",
             corpus_dir,
-            "-i",
-            test_script,
             "--rebuild",
             "always",
             "--num-chips",


### PR DESCRIPTION
Closes #66 

`benchit benchmark` is now semantically similar to `benchit cache delete`:
- `benchit benchmark input_script` is now a positional argument (before: --input-scripts was an optional list of script names)
- `benchit benchmark --all` benchmarks all scripts in the search directory (before: `benchit benchmark` would default to the behavior of `--all`, which would have crazy effects if you called it in the wrong search directory)
- `benchit input_script` still works as before
- `benchit benchmark` with no other args now prints a helpful error message instead of throwing a scary error:

```
(mla) jfowers@jfowers:~/mlagility/models/selftest$ benchit benchmark

error: one of the arguments input_script --all is required
usage: benchit benchmark [-h] [-s SEARCH_DIR] [--all] [--use-slurm] [--lean-cache]
                         [-d CACHE_DIR] [--rebuild REBUILD]
                         [--compiler-flags COMPILER_FLAGS [COMPILER_FLAGS ...]]
                         [--assembler-flags ASSEMBLER_FLAGS [ASSEMBLER_FLAGS ...]]
                         [--num-chips NUM_CHIPS] [--groqview] [--ip IP]
                         [--devices {x86,nvidia,groq} [{x86,nvidia,groq} ...]]
                         [--runtime {ort,trt,groq} [{ort,trt,groq} ...]]
                         [--analyze-only] [--build-only] [--script-args SCRIPT_ARGS]
                         [--max-depth MAX_DEPTH]
                         [input_script]
```