### PR TITLE
Remove tensorflow req that conflicts with groqflow 3.0.1

### DIFF
--- a/models/requirements.txt
+++ b/models/requirements.txt
@@ -10,7 +10,6 @@ torchaudio>=0.10.2
 transformers>=4.21.0
 pytorch-pretrained-biggan>=0.1.1
 timm>=0.6.7
-tensorflow-cpu>=2.9.1
 diffusers>=0.2.4
 requests
 Pillow


### PR DESCRIPTION
Before: `bash src/mlagility/cli/setup_venv.sh` would encounter a pip dependencies conflict.
After: `bash src/mlagility/cli/setup_venv.sh` runs without any errors, and `(mla) jfowers@jfowers:~/mlagility$ benchit benchmark electra.py -s models/transformers_pytorch --build-only` runs correctly.