### PR TITLE
39 save complete exception stack traces to a file when something goes wrong

### DIFF
--- a/examples/cli/negative.py
+++ b/examples/cli/negative.py
@@ -1,0 +1,39 @@
+"""
+The purpose of this script is to demonstrate what happens
+with benchit if the target script throws an exception.
+
+You can try it out with:
+
+benchit negative.py
+
+And you should see benchit direct you to a file that
+contains the stack trace for the exception.
+"""
+
+
+import torch
+
+torch.manual_seed(0)
+
+# Define model class
+class SmallModel(torch.nn.Module):
+    def __init__(self, input_size, output_size):
+        super(SmallModel, self).__init__()
+        self.fc = torch.nn.Linear(input_size, output_size)
+
+    def forward(self, x):
+        output = self.fc(x)
+        a = 1 / 0
+        return output
+
+
+# Instantiate model and generate inputs
+input_size = 10
+output_size = 5
+pytorch_model = SmallModel(input_size, output_size)
+inputs = {"x": torch.rand(input_size)}
+
+pytorch_outputs = pytorch_model(**inputs)
+
+# Print results
+print(f"pytorch_outputs: {pytorch_outputs}")

--- a/models/requirements.txt
+++ b/models/requirements.txt
@@ -10,7 +10,6 @@ torchaudio>=0.10.2
 transformers>=4.21.0
 pytorch-pretrained-biggan>=0.1.1
 timm>=0.6.7
-tensorflow-cpu>=2.9.1
 diffusers>=0.2.4
 requests
 Pillow

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -151,6 +151,9 @@ def call_benchit(
         model_info.status_message = f"Unknown benchit error: {e}"
         model_info.status_message_color = printing.Colors.WARNING
 
+        if os.environ.get("MLAGILITY_DEBUG"):
+            raise e
+
 
 def get_model_hash(
     model: Union[torch.nn.Module, "tf.keras.Model"], model_type: build.ModelType

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -460,10 +460,12 @@ def execute_gpu_locally(state: build.State, device: str, iterations: int) -> Non
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    _, stderr = run_benchmark.communicate()
+    stdout, stderr = run_benchmark.communicate()
     if run_benchmark.returncode != 0:
         raise BenchmarkException(
-            "Error: Failure to run model using TensorRT - " f"{stderr.decode().strip()}"
+            "Error: Failure to run model using TensorRT - "
+            f"{stdout.decode().strip()}"
+            f"{stderr.decode().strip()}"
         )
 
     if not os.path.isfile(local_paths.outputs_file):
@@ -599,10 +601,12 @@ def execute_cpu_locally(state: build.State, device: str, iterations: int) -> Non
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        _, stderr = setup_env.communicate()
+        stdout, stderr = setup_env.communicate()
         if setup_env.returncode != 0:
-            print(
-                f"Error: Failure to setup conda environment - {stderr.decode().strip()}"
+            raise BenchmarkException(
+                "Error: Failure to setup conda environment - "
+                f"{stdout.decode().strip()}"
+                f"{stderr.decode().strip()}"
             )
 
     # Run the benchmark
@@ -619,10 +623,12 @@ def execute_cpu_locally(state: build.State, device: str, iterations: int) -> Non
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    _, stderr = run_benchmark.communicate()
+    stdout, stderr = run_benchmark.communicate()
     if run_benchmark.returncode != 0:
         raise BenchmarkException(
-            f"Error: Failure to run model using onnxruntime - {stderr.decode().strip()}"
+            "Error: Failure to run model using onnxruntime - "
+            f"{stdout.decode().strip()}"
+            f"{stderr.decode().strip()}"
         )
 
     if not os.path.isfile(local_paths.outputs_file):


### PR DESCRIPTION
Before:

```
(mla) jfowers@jfowers:~/mlagility/examples/cli$ benchit keras.py
```
yields
```

Models discovered during profiling:

keras.py:
        trackable (executed 1x)
                Model Type:     Keras (tf.keras.Model)
                Class:          SmallKerasModel (<class 'keras.SmallKerasModel'>)
                Location:       /net/home/jfowers/miniconda3/envs/mla/lib/python3.8/site-packages/tensorflow/python/trackable/data_structures.py, line 163
                Parameters:     55 (<0.1 MB)
                Hash:           5a591a29
                Status:
        Unknown benchit error: Error: Failure to run model using onnxruntime - "
        

keras_outputs: [[0.         0.         0.26279172 0.11433329 0.        ]]

Woohoo! The 'benchmark' command is complete. Use the 'report' command to get a .csv file that summarizes results across all builds in the cache.
```

After, with `MLAGILITY_DEBUG=False`:

```
(mla) jfowers@jfowers:~/mlagility/examples/cli$ benchit keras.py
```
yields
```

Models discovered during profiling:

keras.py:
        trackable (executed 1x)
                Model Type:     Keras (tf.keras.Model)
                Class:          SmallKerasModel (<class 'keras.SmallKerasModel'>)
                Location:       /net/home/jfowers/miniconda3/envs/mla/lib/python3.8/site-packages/tensorflow/python/trackable/data_structures.py, line 163
                Parameters:     55 (<0.1 MB)
                Hash:           5a591a29
                Status:
        Unknown benchit error: Error: Failure to run model using onnxruntime - "
        To see the full stack trace, rerun with `export MLAGILITY_DEBUG=True`.
        

keras_outputs: [[0.         0.         0.26279172 0.11433329 0.        ]]

Woohoo! The 'benchmark' command is complete. Use the 'report' command to get a .csv file that summarizes results across all builds in the cache.
```

After, with `MLAGILITY_DEBUG=True`:

```
(mla) jfowers@jfowers:~/mlagility/examples/cli$ benchit keras.py
```
yields
```
(mla) jfowers@jfowers:~/mlagility/examples/cli$ benchit keras.py
2023-02-15 11:49:38.720375: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.
2023-02-15 11:50:13.338416: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA
To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.

Models discovered during profiling:

keras.py:
        trackable (executed 1x)
                Model Type:     Keras (tf.keras.Model)
                Class:          SmallKerasModel (<class 'keras.SmallKerasModel'>)
                Location:       /net/home/jfowers/miniconda3/envs/mla/lib/python3.8/site-packages/tensorflow/python/trackable/data_structures.py, line 163
                Parameters:     55 (<0.1 MB)
                Hash:           5a591a29
                Status:         Computing...


Warning: groqit() discovered a cached build of keras_5a591a29, but decided to rebuild for the following reasons: 
         
         - Model "keras_5a591a29" changed since the last time it was built. 
         
         groqit() will now rebuild your model to ensure correctness. You can change this policy by setting the groqit(rebuild=...) argument.



GroqFlow is building "keras_5a591a29"
2023-02-15 11:50:14.237735: I tensorflow/core/grappler/clusters/single_machine.cc:358] Starting new session    Optimizing ONNX file   
2023-02-15 11:50:14.259253: I tensorflow/core/grappler/clusters/single_machine.cc:358] Starting new session    Finishing up   
    ✓ Exporting Keras to ONNX   
    ✓ Optimizing ONNX file   
    ✓ Converting to FP16   
    ✓ Finishing up   

Woohoo! Saved to ~/.cache/mlagility/keras_5a591a29

Info: Benchmarking on local x86...
Traceback (most recent call last):
  File "/net/home/jfowers/miniconda3/envs/mla/bin/benchit", line 33, in <module>
    sys.exit(load_entry_point('mlagility', 'console_scripts', 'benchit')())
  File "/home/jfowers/mlagility/src/mlagility/cli/cli.py", line 406, in main
    args.func(args)
  File "/home/jfowers/mlagility/src/mlagility/cli/cli.py", line 52, in benchmark_script_argparse
    benchmark_script(
  File "/home/jfowers/mlagility/src/mlagility/api/script_api.py", line 197, in benchmark_script
    models_found = evaluate_script(tracer_args, script_args)
  File "/home/jfowers/mlagility/src/mlagility/analysis/analysis.py", line 477, in evaluate_script
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/jfowers/mlagility/examples/cli/keras.py", line 35, in <module>
    keras_outputs = keras_model(**inputs)
  File "/net/home/jfowers/miniconda3/envs/mla/lib/python3.8/site-packages/keras/utils/traceback_utils.py", line 70, in error_handler
    raise e.with_traceback(filtered_tb) from None
  File "/home/jfowers/mlagility/src/mlagility/analysis/analysis.py", line 363, in forward_spy
    call_benchit(
  File "/home/jfowers/mlagility/src/mlagility/analysis/analysis.py", line 170, in call_benchit
    raise e
  File "/home/jfowers/mlagility/src/mlagility/analysis/analysis.py", line 110, in call_benchit
    perf = benchmark_model(
  File "/home/jfowers/mlagility/src/mlagility/api/model_api.py", line 178, in benchmark_model
    perf = cpu_model.benchmark(backend=backend)
  File "/home/jfowers/mlagility/src/mlagility/api/ortmodel.py", line 20, in benchmark
    benchmark_results = self._execute(repetitions=repetitions, backend=backend)
  File "/home/jfowers/mlagility/src/mlagility/api/ortmodel.py", line 71, in _execute
    devices.execute_cpu_locally(self.state, self.device, repetitions)
  File "/home/jfowers/mlagility/src/mlagility/api/devices.py", line 628, in execute_cpu_locally
    raise BenchmarkException(
mlagility.api.devices.BenchmarkException: Exception encountered when calling layer 'small_keras_model' (type SmallKerasModel).

Error: Failure to run model using onnxruntime - 

Call arguments received by layer 'small_keras_model' (type SmallKerasModel):
  • x=tf.Tensor(shape=(1, 10), dtype=float32)
```
These beautifully detailed examples brought to you by the bug in #116 
