### PR TITLE
Rev groqflow to test version 3.0.2. Eliminate all keras references from docs and test.

### DIFF
--- a/examples/cli/discovery.md
+++ b/examples/cli/discovery.md
@@ -129,7 +129,7 @@ You can see that `hello_world.py`, `two_models.py`, and `max_depth.py` are all e
 
 ### Maximum Analysis Depth
 
-PyTorch and Keras models (eg, `torch.nn.Module`) are often built out of a collection of smaller instances. For example, a PyTorch multilayer perceptron (MLP) model may be built out of many `torch.nn.Linear` modules.
+PyTorch models (eg, `torch.nn.Module`) are often built out of a collection of smaller instances. For example, a PyTorch multilayer perceptron (MLP) model may be built out of many `torch.nn.Linear` modules.
 
 Sometimes you will be interested to analyze or benchmark those sub-modules, which is where the `--max-depth` argument comes in.
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     package_dir={"": "src"},
     packages=["mlagility"],
     install_requires=[
-        "groqflow @ https://test-files.pythonhosted.org/packages/a0/96/2eba6c53f93e9aa1b9de3f80f01ac23db7256b62d31d932d9814a0367ed4/groqflow-3.0.1.tar.gz",
+        "groqflow @ https://test-files.pythonhosted.org/packages/dd/7a/88995b701257dfaef0b5044cca1f82f18a3eda33367f72b60126f82c89ee/groqflow-3.0.2.tar.gz",
         "invoke>=2.0.0",
     ],
     classifiers=[],

--- a/test/analysis.py
+++ b/test/analysis.py
@@ -229,7 +229,7 @@ class Testing(unittest.TestCase):
         )
         assert np.array_equal(output, (2, 0, 1))
 
-    def test_06_cache(self):
+    def test_05_cache(self):
         model_hash = "60931adb"
         run_analysis(
             [
@@ -247,7 +247,7 @@ class Testing(unittest.TestCase):
         labels_found = labels.load_from_cache(cache_dir, build_name) != {}
         assert cache_is_lean(cache_dir, build_name) and labels_found
 
-    def test_07_generic_args(self):
+    def test_06_generic_args(self):
         output = run_cli(
             [
                 "benchit",
@@ -261,7 +261,7 @@ class Testing(unittest.TestCase):
         )
         assert "Received arg test_arg" in output
 
-    def test_08_valid_mla_args(self):
+    def test_07_valid_mla_args(self):
         height, width, num_channels = parse(["height", "width", "num_channels"])
         cmd = [
             "benchit",
@@ -275,7 +275,7 @@ class Testing(unittest.TestCase):
         expected_output = str([height, width, num_channels + 1])
         assert output == expected_output, f"Got {output} but expected {expected_output}"
 
-    def test_09_invalid_mla_args(self):
+    def test_08_invalid_mla_args(self):
         cmd = [
             "benchit",
             "mla_parser.py",
@@ -286,7 +286,7 @@ class Testing(unittest.TestCase):
         _, stderr = process.communicate()
         assert "error: unrecognized argument" in stderr.decode("utf-8")
 
-    def test_10_pipeline(self):
+    def test_09_pipeline(self):
         output = run_analysis(
             [
                 "benchit",
@@ -296,7 +296,7 @@ class Testing(unittest.TestCase):
         )
         assert np.array_equal(output, (1, 0, 0))
 
-    def test_11_activation(self):
+    def test_10_activation(self):
         output = run_analysis(
             [
                 "benchit",
@@ -306,7 +306,7 @@ class Testing(unittest.TestCase):
         )
         assert np.array_equal(output, (0, 0, 0))
 
-    def test_12_encoder_decoder(self):
+    def test_11_encoder_decoder(self):
         output = run_analysis(
             [
                 "benchit",
@@ -316,7 +316,7 @@ class Testing(unittest.TestCase):
         )
         assert np.array_equal(output, (1, 0, 0))
 
-    def test_13_benchit_hashes(self):
+    def test_12_benchit_hashes(self):
         output = run_analysis(
             [
                 "benchit",

--- a/test/analysis.py
+++ b/test/analysis.py
@@ -68,34 +68,6 @@ inputs = {"x": torch.rand(input_features)}
 output = model(**inputs)
 
 """,
-    "linear_keras": """
-# labels: test_group::selftest license::mit framework::keras tags::selftest,small
-import tensorflow as tf
-
-tf.random.set_seed(0)
-
-# Define model class
-class SmallKerasModel(tf.keras.Model):  # pylint: disable=abstract-method
-    def __init__(self, output_size):
-        super(SmallKerasModel, self).__init__()
-        self.dense = tf.keras.layers.Dense(output_size, activation="relu")
-
-    def call(self, x):  # pylint: disable=arguments-differ
-        output = self.dense(x)
-        return output
-
-
-# Instantiate model and generate inputs
-batch_size = 1
-input_size = 10
-output_size = 5
-keras_model = SmallKerasModel(output_size)
-
-inputs = {"x": tf.random.uniform((batch_size, input_size), dtype=tf.float32)}
-
-keras_outputs = keras_model(**inputs)
-
-""",
     "pipeline": """
 from transformers import (
     TextClassificationPipeline,
@@ -231,18 +203,7 @@ class Testing(unittest.TestCase):
         )
         assert np.array_equal(pytorch_output, (1, 0, 0))
 
-    def test_02_basic_keras(self):
-        keras_output = run_analysis(
-            [
-                "benchit",
-                "linear_keras.py",
-                "--analyze-only",
-            ]
-        )
-        assert np.array_equal(keras_output, (1, 0, 0))
-
     def test_03_depth(self):
-        # Depth is only tested for Pytorch, since Keras has no max_depth support
         output = run_analysis(
             [
                 "benchit",
@@ -267,18 +228,6 @@ class Testing(unittest.TestCase):
             ]
         )
         assert np.array_equal(output, (2, 0, 1))
-
-    def test_05_build_keras(self):
-        output = run_analysis(
-            [
-                "benchit",
-                "linear_keras.py",
-                "--build-only",
-                "--cache-dir",
-                cache_dir,
-            ]
-        )
-        assert np.array_equal(output, (1, 0, 1))
 
     def test_06_cache(self):
         model_hash = "60931adb"

--- a/test/model_api.py
+++ b/test/model_api.py
@@ -3,7 +3,6 @@ import unittest
 import torch
 import shutil
 from pathlib import Path
-import tensorflow as tf
 import groqflow.justgroqit.stage as stage
 import groqflow.common.cache as cache
 import groqflow.justgroqit.export as export
@@ -31,27 +30,12 @@ class AnotherSimplePytorchModel(torch.nn.Module):
         return output
 
 
-class SmallKerasModel(tf.keras.Model):  # pylint: disable=abstract-method
-    def __init__(self):
-        super(SmallKerasModel, self).__init__()
-        self.dense = tf.keras.layers.Dense(10)
-
-    def call(self, x):  # pylint: disable=arguments-differ
-        return self.dense(x)
-
-
 # Define pytorch model and inputs
 pytorch_model = SmallPytorchModel()
 tiny_pytorch_model = AnotherSimplePytorchModel()
 inputs = {"x": torch.rand(10)}
 inputs_2 = {"x": torch.rand(5)}
 input_tensor = torch.rand(10)
-
-# Define keras models and inputs
-batch_keras_inputs = {"x": tf.random.uniform((1, 10), dtype=tf.float32)}
-keras_subclass_model = SmallKerasModel()
-keras_subclass_model.build(input_shape=(1, 10))
-
 
 # Create a test directory
 test_dir = "model_api_test_dir"
@@ -87,20 +71,7 @@ class Testing(unittest.TestCase):
         state = get_build_state(cache_dir, build_name)
         assert state.build_status == build.Status.SUCCESSFUL_BUILD
 
-    def test_002_build_keras_model(self):
-        build_name = "full_compilation_keras_subclass_model"
-        benchmark_model(
-            keras_subclass_model,
-            batch_keras_inputs,
-            build_name=build_name,
-            rebuild="always",
-            build_only=True,
-            cache_dir=cache_dir,
-        )
-        state = get_build_state(cache_dir, build_name)
-        assert state.build_status == build.Status.SUCCESSFUL_BUILD
-
-    def test_003_custom_stage(self):
+    def test_002_custom_stage(self):
         build_name = "custom_stage"
 
         class MyCustomStage(stage.GroqitStage):
@@ -144,7 +115,7 @@ class Testing(unittest.TestCase):
         state = get_build_state(cache_dir, build_name)
         return state.build_status == build.Status.SUCCESSFUL_BUILD
 
-    def test_004_local_benchmark(self):
+    def test_003_local_benchmark(self):
         build_name = "local_benchmark"
         perf = benchmark_model(
             pytorch_model,


### PR DESCRIPTION
TF/Keras was continuing to cause issues for beta testers simply by being part of the python environment. `groqflow 3.0.2` makes the `tensorflow-cpu` package optional, and this update to `mlagility` takes advantage of that to exclude TensorFlow entirely.

Hopefully this will help a lot with the environment/deps issues we've been facing.