### PR TITLE
Analysis saves mlagility stats to state.yaml

### DIFF
--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -23,6 +23,7 @@ import mlagility.analysis.tf_helpers as tf_helpers
 import mlagility.common.labels as labels
 from mlagility.api.model_api import benchmark_model
 import mlagility.common.filesystem as filesystem
+import mlagility.common.groqflow_helpers as groqflow_helpers
 
 
 class Action(Enum):
@@ -144,10 +145,10 @@ def call_benchit(
         model_info.status_message_color = printing.Colors.OKGREEN
 
     except exp.GroqitStageError:
-        load_state = build.load_state(build_name=build_name)
-        if len(load_state.info.opt_onnx_unsupported_ops) > 0:
+        build_state = build.load_state(cache_dir=cache_dir, build_name=build_name)
+        if len(build_state.info.opt_onnx_unsupported_ops) > 0:
             model_info.status_message = "Unsupported op(s) " + ", ".join(
-                load_state.info.opt_onnx_unsupported_ops
+                build_state.info.opt_onnx_unsupported_ops
             )
         else:
             model_info.status_message = "Build Error: see log files for details."
@@ -169,6 +170,20 @@ def call_benchit(
         model_info.status_message_color = printing.Colors.WARNING
 
         _store_traceback(model_info)
+
+    else:
+        # Stats that we want to save into the model's state.yaml file
+        # so that they can be easily accessed by the report command later
+        build_state = build.load_state(cache_dir=cache_dir, build_name=build_name)
+        groqflow_helpers.add_mlagility_stat(build_state, "hash", model_info.hash)
+        groqflow_helpers.add_mlagility_stat(
+            build_state, "parameters", model_info.params
+        )
+
+        if perf is not None:
+            groqflow_helpers.add_mlagility_stat(
+                build_state, f"{tracer_args.device}_performance", vars(perf)
+            )
 
 
 def get_model_hash(

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -182,7 +182,7 @@ def call_benchit(
 
         if perf is not None:
             groqflow_helpers.add_mlagility_stat(
-                build_state, f"{tracer_args.device}_performance", vars(perf)
+                build_state, f"{perf.device} performance", vars(perf)
             )
 
 

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -182,7 +182,8 @@ def benchmark_model(
 
             else:
                 raise ValueError(
-                    f"Only groq, x86, or nvidia are allowed values for device type, but got {device}"
+                    "Only groq, x86, or nvidia are allowed values for device type, "
+                    f"but got {device}"
                 )
 
             # Perform some extra analysis to capture the ONNX model's parameter count and IO size

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -11,7 +11,7 @@ from groqflow.groqmodel import GroqModel
 from mlagility.api import trtmodel, ortmodel
 import mlagility.common.filesystem as filesystem
 from mlagility.api.performance import MeasuredPerformance
-from mlagility.common.groqflow_helpers import SuccessStage
+import mlagility.common.groqflow_helpers as groqflow_helpers
 
 MLAGILITY_DEFAULT_REBUILD_POLICY = "if_needed"
 
@@ -24,7 +24,7 @@ model_type_to_export_sequence = {
             export.ExportPytorchModel(),
             export.OptimizeOnnxModel(),
             export.ConvertOnnxToFp16(),
-            SuccessStage(),
+            groqflow_helpers.SuccessStage(),
         ],
         enable_model_validation=True,
     ),
@@ -35,7 +35,7 @@ model_type_to_export_sequence = {
             export.ExportKerasModel(),
             export.OptimizeOnnxModel(),
             export.ConvertOnnxToFp16(),
-            SuccessStage(),
+            groqflow_helpers.SuccessStage(),
         ],
         enable_model_validation=True,
     ),
@@ -46,7 +46,7 @@ model_type_to_export_sequence = {
             export.ReceiveOnnxModel(),
             export.OptimizeOnnxModel(),
             export.ConvertOnnxToFp16(),
-            SuccessStage(),
+            groqflow_helpers.SuccessStage(),
         ],
         enable_model_validation=True,
     ),
@@ -57,7 +57,7 @@ model_type_to_export_sequence = {
             hummingbird.ConvertHummingbirdModel(),
             export.OptimizeOnnxModel(),
             export.ConvertOnnxToFp16(),
-            SuccessStage(),
+            groqflow_helpers.SuccessStage(),
         ],
         enable_model_validation=True,
     ),
@@ -145,52 +145,45 @@ def benchmark_model(
                     build_name=gmodel.state.config.build_name,
                 )
 
+        elif device == "nvidia":
+            gmodel = exportit(
+                model=model,
+                inputs=inputs,
+                build_name=build_name,
+                cache_dir=cache_dir,
+                rebuild=rebuild,
+                sequence=sequence,
+            )
+
+            if not build_only:
+                printing.log_info(f"Benchmarking on {backend} {device}...")
+                gpu_model = trtmodel.load(
+                    gmodel.state.config.build_name, cache_dir=gmodel.state.cache_dir
+                )
+                perf = gpu_model.benchmark(backend=backend)
+
+        elif device == "x86":
+            gmodel = exportit(
+                model=model,
+                inputs=inputs,
+                build_name=build_name,
+                cache_dir=cache_dir,
+                rebuild=rebuild,
+                sequence=sequence,
+            )
+
+            if not build_only:
+                printing.log_info(f"Benchmarking on {backend} {device}...")
+                cpu_model = ortmodel.load(
+                    gmodel.state.config.build_name, cache_dir=gmodel.state.cache_dir
+                )
+                perf = cpu_model.benchmark(backend=backend)
+
         else:
-            if device == "nvidia":
-                gmodel = exportit(
-                    model=model,
-                    inputs=inputs,
-                    build_name=build_name,
-                    cache_dir=cache_dir,
-                    rebuild=rebuild,
-                    sequence=sequence,
-                )
-
-                if not build_only:
-                    printing.log_info(f"Benchmarking on {backend} {device}...")
-                    gpu_model = trtmodel.load(
-                        gmodel.state.config.build_name, cache_dir=gmodel.state.cache_dir
-                    )
-                    perf = gpu_model.benchmark(backend=backend)
-
-            elif device == "x86":
-                gmodel = exportit(
-                    model=model,
-                    inputs=inputs,
-                    build_name=build_name,
-                    cache_dir=cache_dir,
-                    rebuild=rebuild,
-                    sequence=sequence,
-                )
-
-                if not build_only:
-                    printing.log_info(f"Benchmarking on {backend} {device}...")
-                    cpu_model = ortmodel.load(
-                        gmodel.state.config.build_name, cache_dir=gmodel.state.cache_dir
-                    )
-                    perf = cpu_model.benchmark(backend=backend)
-
-            else:
-                raise ValueError(
-                    "Only groq, x86, or nvidia are allowed values for device type, "
-                    f"but got {device}"
-                )
-
-            # Perform some extra analysis to capture the ONNX model's parameter count and IO size
-            compile.get_and_analyze_onnx(gmodel.state)
-
-            # Save any changes made to the State instance to disk
-            gmodel.state.save()
+            raise ValueError(
+                "Only groq, x86, or nvidia are allowed values for device type, "
+                f"but got {device}"
+            )
 
     finally:
         # Make sure the build and cache dirs exist and have the proper marker files

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -4,7 +4,6 @@ import groqflow.common.build as build
 from groqflow.justgroqit.stage import Sequence
 from groqflow.justgroqit.ignition import identify_model_type
 import groqflow.justgroqit.export as export
-import groqflow.justgroqit.compile as compile
 import groqflow.justgroqit.hummingbird as hummingbird
 import groqflow.common.printing as printing
 from groqflow.groqmodel import GroqModel

--- a/src/mlagility/common/groqflow_helpers.py
+++ b/src/mlagility/common/groqflow_helpers.py
@@ -23,3 +23,11 @@ class SuccessStage(GroqitStage):
         state.build_status = build.Status.SUCCESSFUL_BUILD
 
         return state
+
+
+def add_mlagility_stat(state: build.State, key, value):
+    if not hasattr(state.info, "mlagility"):
+        state.info.mlagility = {}
+
+    state.info.mlagility[key] = value
+    state.save()


### PR DESCRIPTION
Closes #151 
Closes #149 

proof:

```
(mla) jfowers@jfowers:~/mlagility$ benchit examples/cli/scripts/hello_world.py --device x86 -d tmp_cache --rebuild always

(mla) jfowers@jfowers:~/mlagility$ benchit cache stats hello_world_479b1332 -d tmp_cache

...
  mlagility:
    Intel(R) Xeon(R) CPU @ 2.20GHz performance:
      build_name: hello_world_479b1332
      device: Intel(R) Xeon(R) CPU @ 2.20GHz
      device_type: x86
      latency_units: milliseconds (ms)
      mean_latency: 0.0002015545964241028
      throughput: 496143.4855575517
      throughput_units: inferences per second (IPS)
    hash: 479b1332
    parameters: 55
...
```