### PR TITLE
Move MLAgility stats out of groqflow yaml into its own yaml

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ However, if you want to use mlagility with your Groq SDK and GroqChip processor 
 
 ## Installing Slurm support
 
-Slurm is an open source workload manager for clusters. If you would like to use Slurm to build multiple models simultaneously, please follow the instructions below. Please note that MLAgility requires the Slurm nodes to have access to at least 128GB of RAM.
+Slurm is an open source workload manager for clusters. If you would like to use slurm to build multiple models simultaneously, please follow the instructions below.
 
 ### Setup your Slurm environment
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -48,7 +48,7 @@ However, if you want to use mlagility with your Groq SDK and GroqChip processor 
 
 ## Installing Slurm support
 
-Slurm is an open source workload manager for clusters. If you would like to use slurm to build multiple models simultaneously, please follow the instructions below. 
+Slurm is an open source workload manager for clusters. If you would like to use Slurm to build multiple models simultaneously, please follow the instructions below. Please note that MLAgility requires the Slurm nodes to have access to at least 128GB of RAM.
 
 ### Setup your Slurm environment
 

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -23,7 +23,6 @@ import mlagility.analysis.tf_helpers as tf_helpers
 import mlagility.common.labels as labels
 from mlagility.api.model_api import benchmark_model
 import mlagility.common.filesystem as filesystem
-import mlagility.common.groqflow_helpers as groqflow_helpers
 
 
 class Action(Enum):
@@ -169,19 +168,20 @@ def call_benchit(
         _store_traceback(model_info)
 
     else:
-        # Stats that we want to save into the model's state.yaml file
+        # Stats that we want to save into the build's mlagility_stats.yaml file
         # so that they can be easily accessed by the report command later
-        build_state = build.load_state(
-            cache_dir=tracer_args.cache_dir, build_name=build_name
+        filesystem.save_stat(tracer_args.cache_dir, build_name, "hash", model_info.hash)
+        filesystem.save_stat(
+            tracer_args.cache_dir, build_name, "parameters", model_info.params
         )
-        groqflow_helpers.add_mlagility_stat(build_state, "hash", model_info.hash)
-        # groqflow_helpers.add_mlagility_stat(
-        #    build_state, "parameters", model_info.params
-        # )
 
         if perf is not None:
-            groqflow_helpers.add_mlagility_stat(
-                build_state, f"{perf.device} performance", vars(perf)
+            filesystem.add_sub_stat(
+                cache_dir=tracer_args.cache_dir,
+                build_name=build_name,
+                parent_key="performance",
+                key=perf.device,
+                value=vars(perf),
             )
 
 

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -175,7 +175,7 @@ def call_benchit(
             tracer_args.cache_dir, build_name, "parameters", model_info.params
         )
 
-        if perf is not None:
+        if perf:
             filesystem.add_sub_stat(
                 cache_dir=tracer_args.cache_dir,
                 build_name=build_name,

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -28,20 +28,13 @@ def print_version(_):
     print(mlagility_version)
 
 
-def print_state(args):
-    printing.log_info(
-        f"The state of build {args.build_name} in cache {args.cache_dir} is:"
-    )
-
+def print_stats(args):
     state_path = build.state_file(args.cache_dir, args.build_name)
-    if os.path.exists(state_path):
-        with open(state_path, "r", encoding="utf-8") as file:
-            print(file.read())
-    else:
-        printing.log_error(
-            f"No build found with name: {build}. "
-            "Try running `benchit cache list` to see the builds in your build cache."
-        )
+    filesystem.print_yaml_file(state_path, "GroqFlow build state")
+
+    filesystem.print_yaml_file(
+        filesystem.stats_file(args.cache_dir, args.build_name), "MLAgility stats"
+    )
 
 
 def benchmark_script_argparse(args):
@@ -326,7 +319,7 @@ def main():
     stats_parser = cache_subparsers.add_parser(
         "stats", help="Print stats about a build in a target cache"
     )
-    stats_parser.set_defaults(func=print_state)
+    stats_parser.set_defaults(func=print_stats)
 
     stats_parser.add_argument(
         "-d",

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import sys
 import groqflow.common.build as build
-import groqflow.common.printing as printing
 import mlagility.common.filesystem as filesystem
 import mlagility.cli.report as report
 from mlagility.api.script_api import benchmark_script

--- a/src/mlagility/common/filesystem.py
+++ b/src/mlagility/common/filesystem.py
@@ -283,17 +283,26 @@ def stats_file_exists():
     return os.path.isfile(stats_file)
 
 
+def get_stats(cache_dir: str, build_name: str):
+    stats_path = stats_file(cache_dir, build_name)
+    return _load_yaml(stats_path)
+
+
+def _save_stats(cache_dir: str, build_name: str, stats_dict: Dict):
+    stats_path = stats_file(cache_dir, build_name)
+    _save_yaml(stats_dict, stats_path)
+
+
 def save_stat(cache_dir: str, build_name: str, key: str, value):
     """
     Save statistics to an yaml file in the build directory
     """
 
-    stats_path = stats_file(cache_dir, build_name)
-    stats_dict = _load_yaml(stats_path)
+    stats_dict = get_stats(cache_dir, build_name)
 
     stats_dict[key] = value
 
-    _save_yaml(stats_dict, stats_path)
+    _save_stats(cache_dir, build_name, stats_dict)
 
 
 def add_sub_stat(cache_dir: str, build_name: str, parent_key: str, key: str, value):
@@ -301,8 +310,7 @@ def add_sub_stat(cache_dir: str, build_name: str, parent_key: str, key: str, val
     Save statistics to an yaml file in the build directory
     """
 
-    stats_path = stats_file(cache_dir, build_name)
-    stats_dict = _load_yaml(stats_path)
+    stats_dict = get_stats(cache_dir, build_name)
 
     if parent_key in stats_dict.keys():
         dict_to_update = stats_dict[parent_key]
@@ -312,4 +320,4 @@ def add_sub_stat(cache_dir: str, build_name: str, parent_key: str, key: str, val
     dict_to_update[key] = value
     stats_dict[parent_key] = dict_to_update
 
-    _save_yaml(stats_dict, stats_path)
+    _save_stats(cache_dir, build_name, stats_dict)

--- a/src/mlagility/common/filesystem.py
+++ b/src/mlagility/common/filesystem.py
@@ -27,6 +27,31 @@ class CacheError(exc.GroqFlowError):
     """
 
 
+def _load_yaml(file) -> Dict:
+    if os.path.isfile(file):
+        with open(file, "r", encoding="utf8") as stream:
+            return yaml.load(stream, Loader=yaml.FullLoader)
+    else:
+        return {}
+
+
+def _save_yaml(dict: Dict, file):
+    with open(file, "w", encoding="utf8") as outfile:
+        yaml.dump(dict, outfile)
+
+
+def print_yaml_file(file_path, description):
+    if os.path.exists(file_path):
+        with open(file_path, "r", encoding="utf-8") as file:
+            printing.log_info(f"The {description} for {file_path} are:")
+            print(file.read())
+    else:
+        raise CacheError(
+            f"No {description} found at {file_path}. "
+            "Try running `benchit cache list` to see the builds in your build cache."
+        )
+
+
 class CacheDatabase:
     def __init__(self, cache_dir):
         self.cache_dir = cache_dir
@@ -37,17 +62,7 @@ class CacheDatabase:
 
     @property
     def _database(self) -> Dict[str, Dict[str, str]]:
-        if os.path.isfile(self._database_file):
-            with open(self._database_file, "r", encoding="utf8") as stream:
-                database = yaml.load(stream, Loader=yaml.FullLoader)
-        else:
-            database = {}
-
-        return database
-
-    def _save_database(self, database_dict: Dict):
-        with open(self._database_file, "w", encoding="utf8") as outfile:
-            yaml.dump(database_dict, outfile)
+        return _load_yaml(self._database_file)
 
     def script_in_database(self, script_name) -> bool:
         return script_name in self._database.keys()
@@ -68,7 +83,7 @@ class CacheDatabase:
         if script_name not in database_dict.keys():
             database_dict[script_name] = {}
 
-        self._save_database(database_dict)
+        _save_yaml(database_dict, self._database_file)
 
     def add_build(self, script_name, build_name):
         self.add_script(script_name)
@@ -77,7 +92,7 @@ class CacheDatabase:
 
         database_dict[script_name][build_name] = datetime.datetime.now()
 
-        self._save_database(database_dict)
+        _save_yaml(database_dict, self._database_file)
 
     def remove_script(self, script_name: str) -> Dict[str, Dict[str, str]]:
         self._validate_script_in_database(script_name, "remove_script")
@@ -86,7 +101,7 @@ class CacheDatabase:
 
         database_dict.pop(script_name)
 
-        self._save_database(database_dict)
+        _save_yaml(database_dict, self._database_file)
 
         return database_dict
 
@@ -101,7 +116,7 @@ class CacheDatabase:
                 if len(script_builds) == 0:
                     database_dict = self.remove_script(script_name)
 
-        self._save_database(database_dict)
+        _save_yaml(database_dict, self._database_file)
 
 
 def make_cache_dir(cache_dir: str):
@@ -258,3 +273,43 @@ def get_builds_from_script(cache_dir, script_name):
     script_builds = [x for x in all_builds_in_cache if script_name in x]
 
     return script_builds
+
+
+def stats_file(cache_dir: str, build_name: str):
+    return os.path.join(build.output_dir(cache_dir, build_name), "mlagility_stats.yaml")
+
+
+def stats_file_exists():
+    return os.path.isfile(stats_file)
+
+
+def save_stat(cache_dir: str, build_name: str, key: str, value):
+    """
+    Save statistics to an yaml file in the build directory
+    """
+
+    stats_path = stats_file(cache_dir, build_name)
+    stats_dict = _load_yaml(stats_path)
+
+    stats_dict[key] = value
+
+    _save_yaml(stats_dict, stats_path)
+
+
+def add_sub_stat(cache_dir: str, build_name: str, parent_key: str, key: str, value):
+    """
+    Save statistics to an yaml file in the build directory
+    """
+
+    stats_path = stats_file(cache_dir, build_name)
+    stats_dict = _load_yaml(stats_path)
+
+    if parent_key in stats_dict.keys():
+        dict_to_update = stats_dict[parent_key]
+    else:
+        dict_to_update = {}
+
+    dict_to_update[key] = value
+    stats_dict[parent_key] = dict_to_update
+
+    _save_yaml(stats_dict, stats_path)

--- a/src/mlagility/common/groqflow_helpers.py
+++ b/src/mlagility/common/groqflow_helpers.py
@@ -23,11 +23,3 @@ class SuccessStage(GroqitStage):
         state.build_status = build.Status.SUCCESSFUL_BUILD
 
         return state
-
-
-def add_mlagility_stat(state: build.State, key, value):
-    if not hasattr(state.info, "mlagility"):
-        state.info.mlagility = {}
-
-    state.info.mlagility[key] = value
-    state.save()


### PR DESCRIPTION
- Closes #151 
- MLAgility parameter count, hash value in the report now come mlagility_stats.yaml
- `benchit cache stats` now prints out mlagility_stats.yaml
- Extended the `benchit cache stats` test to test mlagility_stats.yaml
- Benchmark performance is also included in mlagility_stats.yaml so that it shows up in `benchit cache stats`, but not using it for anything else yet
