### PR TITLE
Fix slurm/database interactions

### DIFF
--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -471,10 +471,6 @@ def evaluate_script(
 ) -> Dict[str, util.ModelInfo]:
     tracer_args.script_name = clean_script_name(tracer_args.input)
 
-    # Add the script to the database
-    db = filesystem.CacheDatabase(tracer_args.cache_dir)
-    db.add_script(tracer_args.script_name)
-
     # Get a pointer to the script's python module
     spec = importlib.util.spec_from_file_location(
         tracer_args.script_name, tracer_args.input

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -7,7 +7,6 @@ import time
 import shlex
 import functools
 import dataclasses
-import pathlib
 import traceback
 from typing import Union, List, Dict
 from types import FrameType, TracebackType
@@ -461,15 +460,10 @@ def recursive_search(
                 )
 
 
-def clean_script_name(script_path: str) -> str:
-    # Trim the ".py"
-    return pathlib.Path(script_path).stem
-
-
 def evaluate_script(
     tracer_args: TracerArgs, input_args: str = None
 ) -> Dict[str, util.ModelInfo]:
-    tracer_args.script_name = clean_script_name(tracer_args.input)
+    tracer_args.script_name = filesystem.clean_script_name(tracer_args.input)
 
     # Get a pointer to the script's python module
     spec = importlib.util.spec_from_file_location(

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -125,7 +125,7 @@ def benchmark_model(
         db = filesystem.CacheDatabase(cache_dir)
 
         if script_name is None:
-            db_script_name = sys.argv[0].split("/")[-1].split(".")[0]
+            db_script_name = filesystem.clean_script_name(sys.argv[0])
         else:
             db_script_name = script_name
 

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -120,7 +120,7 @@ def benchmark_model(
     # Make sure the cache exists, and populate the cache database
     # with this script and build.
     # Skip this if we are in Slurm mode; it will be done in the main process
-    if os.environ.get("USING_SLURM") != "True":
+    if os.environ.get("USING_SLURM") != "TRUE":
         filesystem.make_cache_dir(cache_dir)
         db = filesystem.CacheDatabase(cache_dir)
 

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from typing import Any, Dict, Optional, List
 from groqflow import groqit
 import groqflow.common.build as build
@@ -118,15 +119,17 @@ def benchmark_model(
 
     # Make sure the cache exists, and populate the cache database
     # with this script and build.
-    filesystem.make_cache_dir(cache_dir)
-    db = filesystem.CacheDatabase(cache_dir)
+    # Skip this if we are in Slurm mode; it will be done in the main process
+    if os.environ.get("USING_SLURM") != "True":
+        filesystem.make_cache_dir(cache_dir)
+        db = filesystem.CacheDatabase(cache_dir)
 
-    if script_name is None:
-        db_script_name = sys.argv[0].split("/")[-1].split(".")[0]
-    else:
-        db_script_name = script_name
+        if script_name is None:
+            db_script_name = sys.argv[0].split("/")[-1].split(".")[0]
+        else:
+            db_script_name = script_name
 
-    db.add_build(db_script_name, build_name)
+        db.add_build(db_script_name, build_name)
 
     # Build and benchmark the model
     try:

--- a/src/mlagility/api/script_api.py
+++ b/src/mlagility/api/script_api.py
@@ -13,7 +13,6 @@ from mlagility.analysis.analysis import (
     evaluate_script,
     TracerArgs,
     Action,
-    clean_script_name,
 )
 from mlagility.analysis.util import ModelInfo
 
@@ -170,13 +169,13 @@ def benchmark_script(
         # We keep track of that using the cache database
         db = filesystem.CacheDatabase(cache_dir)
         if db.exists():
-            if resume and db.script_in_database(clean_script_name(script)):
+            if resume and db.script_in_database(filesystem.clean_script_name(script)):
                 continue
 
         # Add the script to the database
         # Skip this if we are in Slurm mode; it has already been done in the main process
         if os.environ.get("USING_SLURM") != "TRUE":
-            db.add_script(clean_script_name(script))
+            db.add_script(filesystem.clean_script_name(script))
 
         for device in devices:
             if use_slurm:

--- a/src/mlagility/api/script_api.py
+++ b/src/mlagility/api/script_api.py
@@ -176,7 +176,6 @@ def benchmark_script(
         # Add the script to the database
         # Skip this if we are in Slurm mode; it has already been done in the main process
         if os.environ.get("USING_SLURM") != "TRUE":
-            db = filesystem.CacheDatabase(cache_dir)
             db.add_script(clean_script_name(script))
 
         for device in devices:
@@ -232,12 +231,6 @@ def benchmark_script(
             )
             time.sleep(5)
 
-        # In the parent process, add all builds to the cache database
-        if os.environ.get("USING_SLURM") != "TRUE":
-            db = filesystem.CacheDatabase(cache_dir)
-            for script in input_scripts:
-                builds = filesystem.get_builds_from_script(cache_dir, script)
-                for build in builds:
-                    db.add_build(script, build)
+        slurm.update_database_builds(cache_dir, input_scripts)
 
     printing.log_success("The 'benchmark' command is complete.")

--- a/src/mlagility/api/script_api.py
+++ b/src/mlagility/api/script_api.py
@@ -232,11 +232,12 @@ def benchmark_script(
             )
             time.sleep(5)
 
-        # Add all builds to the cache database
-        db = filesystem.CacheDatabase(cache_dir)
-        for script in input_scripts:
-            builds = filesystem.get_builds_from_script(cache_dir, script)
-            for build in builds:
-                db.add_build(script, build)
+        # In the parent process, add all builds to the cache database
+        if os.environ.get("USING_SLURM") != "True":
+            db = filesystem.CacheDatabase(cache_dir)
+            for script in input_scripts:
+                builds = filesystem.get_builds_from_script(cache_dir, script)
+                for build in builds:
+                    db.add_build(script, build)
 
     printing.log_success("The 'benchmark' command is complete.")

--- a/src/mlagility/api/script_api.py
+++ b/src/mlagility/api/script_api.py
@@ -175,7 +175,7 @@ def benchmark_script(
 
         # Add the script to the database
         # Skip this if we are in Slurm mode; it has already been done in the main process
-        if os.environ.get("USING_SLURM") != "True":
+        if os.environ.get("USING_SLURM") != "TRUE":
             db = filesystem.CacheDatabase(cache_dir)
             db.add_script(clean_script_name(script))
 
@@ -233,7 +233,7 @@ def benchmark_script(
             time.sleep(5)
 
         # In the parent process, add all builds to the cache database
-        if os.environ.get("USING_SLURM") != "True":
+        if os.environ.get("USING_SLURM") != "TRUE":
             db = filesystem.CacheDatabase(cache_dir)
             for script in input_scripts:
                 builds = filesystem.get_builds_from_script(cache_dir, script)

--- a/src/mlagility/cli/slurm.py
+++ b/src/mlagility/cli/slurm.py
@@ -5,7 +5,6 @@ import time
 import getpass
 from typing import List, Optional
 import mlagility.common.filesystem as filesystem
-import mlagility.analysis.analysis as analysis
 
 
 def jobs_in_queue(job_name=None) -> List[str]:
@@ -100,7 +99,7 @@ def run_benchit(
     )
 
     # Remove the .py extension from the build name
-    job_name = analysis.clean_script_name(script)
+    job_name = filesystem.clean_script_name(script)
 
     while len(jobs_in_queue()) >= max_jobs:
         print(
@@ -137,7 +136,7 @@ def update_database_builds(cache_dir, input_scripts):
     if os.environ.get("USING_SLURM") != "TRUE":
         db = filesystem.CacheDatabase(cache_dir)
         for script in input_scripts:
-            clean_script_name = analysis.clean_script_name(script)
+            clean_script_name = filesystem.clean_script_name(script)
             builds = filesystem.get_builds_from_script(cache_dir, clean_script_name)
             for build in builds:
                 db.add_build(clean_script_name, build)

--- a/src/mlagility/common/filesystem.py
+++ b/src/mlagility/common/filesystem.py
@@ -268,9 +268,21 @@ def clean_builds(args):
             )
 
 
+def build_name_to_script_name(build_name: str) -> str:
+    """
+    Convert a build name to the name of the script it came from
+    Build names have the format: <script_name>_hash
+    """
+
+    # Get everything except the trailing _<hash>
+    return "_".join(build_name.split("_")[:-1])
+
+
 def get_builds_from_script(cache_dir, script_name):
     all_builds_in_cache = get_available_builds(cache_dir)
-    script_builds = [x for x in all_builds_in_cache if script_name in x]
+    script_builds = [
+        x for x in all_builds_in_cache if script_name == build_name_to_script_name(x)
+    ]
 
     return script_builds
 

--- a/src/mlagility/common/filesystem.py
+++ b/src/mlagility/common/filesystem.py
@@ -21,6 +21,11 @@ CACHE_MARKER = ".mlacache"
 BUILD_MARKER = ".mlabuild"
 
 
+def clean_script_name(script_path: str) -> str:
+    # Trim the ".py"
+    return pathlib.Path(script_path).stem
+
+
 class CacheError(exc.GroqFlowError):
     """
     Raise this exception when the cache is being accessed incorrectly

--- a/src/mlagility/common/labels.py
+++ b/src/mlagility/common/labels.py
@@ -68,11 +68,8 @@ def save_to_cache(cache_dir: str, build_name: str, label_dict: Dict[str, List[st
     labels_list = [f"{k}::{','.join(label_dict[k])}" for k in label_dict.keys()]
 
     # Create labels folder if it doesn't exist
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
     labels_dir = os.path.join(cache_dir, "labels")
-    if not os.path.exists(labels_dir):
-        os.makedirs(labels_dir)
+    os.makedirs(labels_dir, exist_ok=True)
 
     # Save labels to cache
     file_path = os.path.join(labels_dir, f"{build_name}.txt")


### PR DESCRIPTION
Closes #169 

Previous implementation of both labels and cache database were not process safe. This PR remedies that.

- All access to the cache database is now wrapped with a conditional that prevents it from happening in a slurm node. 
- Labels generation now allows multiple processes to create the labels dir simultaniously