### PR TITLE
Enable cache sharing

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -69,6 +69,15 @@ To allow slurm to use your api token, simply export your token as an environment
 export HUGGINGFACE_API_KEY=<YOUR_API_KEY>
 ```
 
+### Setup a shared download folder (optional)
+
+Both Torch Hub and Hugging Face models save model content to a local cache. A good practice is to store that data with users that might use the same models using a shared folder. MLAgility allows you to setup a shared ML download cache folder when using Slurm by exporting an environment variable as shown below:
+
+
+```
+export SLURM_ML_CACHE=<PATH_TO_A_SHARED_FOLDER>
+```
+
 ### Test it
 
 Go to the mlagility folder and build multiple models simultaneously using Slurm.

--- a/src/mlagility/cli/slurm.py
+++ b/src/mlagility/cli/slurm.py
@@ -74,7 +74,7 @@ def run_benchit(
     build_only: Optional[bool] = None,
     lean_cache: Optional[bool] = None,
     working_dir: str = os.getcwd(),
-    ml_cache_dir: Optional[str] = None,
+    ml_cache_dir: Optional[str] = os.environ.get("ML_CACHE"),
     max_jobs: int = 50,
 ):
 

--- a/src/mlagility/cli/slurm.py
+++ b/src/mlagility/cli/slurm.py
@@ -74,7 +74,7 @@ def run_benchit(
     build_only: Optional[bool] = None,
     lean_cache: Optional[bool] = None,
     working_dir: str = os.getcwd(),
-    ml_cache_dir: Optional[str] = os.environ.get("ML_CACHE"),
+    ml_cache_dir: Optional[str] = os.environ.get("SLURM_ML_CACHE"),
     max_jobs: int = 50,
 ):
 


### PR DESCRIPTION
This one line change enables cache sharing using an environment variable.
It also maintains the ability of changing the ML_CACHE using the API.

Example:
`export ML_CACHE=/net/ml-cache`