### PR TITLE
Ensure that the contents of a failing `benchit` run are not cleared

### DIFF
--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -137,8 +137,6 @@ def call_benchit(
             model_info.status_message = "Model successfully built!"
         model_info.status_message_color = printing.Colors.OKGREEN
 
-        status.update(tracer_args.models_found)
-
     except exp.GroqitStageError:
         build_state = build.load_state(
             cache_dir=tracer_args.cache_dir, build_name=build_name
@@ -184,6 +182,10 @@ def call_benchit(
                 key=perf.device,
                 value=vars(perf),
             )
+    finally:
+        # Ensure that stdout is not being forwarded before updating status
+        sys.stdout = sys.__stdout__
+        status.update(tracer_args.models_found)
 
 
 def get_model_hash(

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -137,6 +137,8 @@ def call_benchit(
             model_info.status_message = "Model successfully built!"
         model_info.status_message_color = printing.Colors.OKGREEN
 
+        status.update(tracer_args.models_found)
+
     except exp.GroqitStageError:
         build_state = build.load_state(
             cache_dir=tracer_args.cache_dir, build_name=build_name
@@ -381,8 +383,6 @@ def explore_frame(
                 )
                 # Ensure that groqit() doesn't interfere with our execution count
                 model_info.executed = 1
-
-            status.update(tracer_args.models_found)
 
             # Turn tracing on again after computing the outputs
             sys.setprofile(tracer)

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -184,7 +184,8 @@ def call_benchit(
             )
     finally:
         # Ensure that stdout is not being forwarded before updating status
-        sys.stdout = sys.__stdout__
+        if hasattr(sys.stdout, "terminal"):
+            sys.stdout = sys.stdout.terminal
         status.update(tracer_args.models_found)
 
 
@@ -385,6 +386,8 @@ def explore_frame(
                 )
                 # Ensure that groqit() doesn't interfere with our execution count
                 model_info.executed = 1
+
+            status.update(tracer_args.models_found)
 
             # Turn tracing on again after computing the outputs
             sys.setprofile(tracer)


### PR DESCRIPTION
Closes https://github.com/groq/mlagility/issues/168

**Issue:**

Status is written to log file if an exception occurs while stdout is being forwarded to a file.

**What this MR does:**

Ensures that stdout is not being forwarded when printing the status

**Key differences:**

`benchit models/selftest/linear.py --device groq --build-only` before change:

```
<ABSOLUTELY NOTHING ON THE SCREEN>
```

---

`benchit models/selftest/linear.py --device groq --build-only` after change:

```
Models discovered during profiling:

linear.py:
        model (executed 1x)
                Model Type:     Pytorch (torch.nn.Module)
                Class:          LinearTestModel (<class 'linear.LinearTestModel'>)
                Location:       /net/home/dhnoronha/mlagility/models/selftest/linear.py, line 21
                Parameters:     110 (<0.1 MB)
                Hash:           d5b1df11
                Status:         GroqFlowError: see log files for details.
                                To see the full stack trace, rerun with `export MLAGILITY_TRACEBACK=True`.


Woohoo! The 'benchmark' command is complete.
```
