### PR TITLE
Rename tracker_slurm to mla_slurm conda envs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,6 @@ jobs:
         shell: bash -el {0}
         run: |
           bash src/mlagility/cli/setup_venv.sh
-          conda activate tracker_slurm
+          conda activate mla_slurm
           python -m pip check
           conda deactivate

--- a/src/mlagility/cli/run_slurm.sh
+++ b/src/mlagility/cli/run_slurm.sh
@@ -5,7 +5,7 @@ WORKING_DIRECTORY="$3"
 ML_CACHE="$4"
 
 source "$(dirname $(dirname $(which conda)))"/etc/profile.d/conda.sh
-conda activate tracker_slurm
+conda activate mla_slurm
 export USING_SLURM="TRUE"
 
 # Export ML cache dir if needed

--- a/src/mlagility/cli/setup_venv.sh
+++ b/src/mlagility/cli/setup_venv.sh
@@ -8,7 +8,7 @@ source "$(dirname $(dirname $(which conda)))"/etc/profile.d/conda.sh
 
 # Parse arguments
 MLAGILITY_PATH=${1:-"$PWD"}
-ENV_NAME=${2:-tracker_slurm}
+ENV_NAME=${2:-mla_slurm}
 
 # Create environment (if it doen't exist)
 export CONDA_ALWAYS_YES="true"


### PR DESCRIPTION
Making local and slurm conda env names consistent.