### PR TITLE
Make sure dashboard clearly shows the reference number of models as part of the bar chart 

### DIFF
--- a/trackers/huggingface/app.py
+++ b/trackers/huggingface/app.py
@@ -59,7 +59,7 @@ def add_faq() -> None:
         [
             "<b>x86</b>: Intel(R) Xeon(R) X40 CPU @ 2.00GHz on Google Cloud (custom: n2, 80 vCPU, 64.00 GiB) and OnnxRuntime version 1.14.0.",
             "<b>nvidia</b>: NVIDIA A100 40GB on Google Cloud (a2-highgpu-1g) and TensorRT version 22.12-py3.",
-            "<b>groq</b>: GroqChip 1 on selfhosted GroqNode server, GroqFlow version 3.0.2 TestPyPI package, and GroqWare™ Suite version 0.9.2.",
+            "<b>groq</b>: GroqChip 1 on selfhosted GroqNode server, GroqFlow version 3.0.2 TestPyPI package, and a pre-release of GroqWare™ Suite version 0.10.0.",
             (
                 "You can find more details about the methodology "
                 '<a href="https://github.com/groq/mlagility/blob/main/docs/tools_user_guide.md">here</a>.'

--- a/trackers/huggingface/graphs.py
+++ b/trackers/huggingface/graphs.py
@@ -490,15 +490,20 @@ def speedup_bar_chart(df: pd.DataFrame, baseline) -> None:
         )
 
 
-def kpi_to_markdown(compute_ratio, device, is_baseline=False, color="blue"):
+def kpi_to_markdown(
+    compute_ratio, device, num_baseline_models, is_baseline=False, color="blue"
+):
 
-    title = f"""<br><br>
-    <p style="font-family:sans-serif; font-size: 20px;text-align: center;">Median {device} Acceleration ({len(compute_ratio)} models):</p>"""
     if is_baseline:
+        title = f"""<br><br>
+        <p style="font-family:sans-serif; font-size: 20px;text-align: center;">Median {device} Acceleration ({len(compute_ratio)} models):</p>"""
         return (
             title
             + f"""<p style="font-family:sans-serif; color:{colors[color]}; font-size: 26px;text-align: center;"> {1}x (Baseline)</p>"""
         )
+
+    title = f"""<br><br>
+    <p style="font-family:sans-serif; font-size: 20px;text-align: center;">Median {device} Acceleration ({len(compute_ratio)}/{num_baseline_models} models):</p>"""
 
     if len(compute_ratio) > 0:
         kpi_min, kpi_median, kpi_max = (
@@ -534,21 +539,25 @@ def speedup_text_summary(df: pd.DataFrame, baseline) -> None:
     nvidia_compute_ratio = nvidia_compute_ratio[nvidia_compute_ratio != 0]
     groq_compute_ratio = groq_compute_ratio[groq_compute_ratio != 0]
 
+    num_baseline_models = len(df[f"{baseline}_compute_ratio"])
     x86_text = kpi_to_markdown(
         x86_compute_ratio,
         device="Intel(R) Xeon(R) X40 CPU @ 2.00GHz",
+        num_baseline_models=num_baseline_models,
         color="blue",
         is_baseline=baseline == "x86",
     )
     groq_text = kpi_to_markdown(
         groq_compute_ratio,
-        device="GroqChip 1",
+        device="GroqChip 1 Estimated",
+        num_baseline_models=num_baseline_models,
         color="orange",
         is_baseline=baseline == "groq",
     )
     nvidia_text = kpi_to_markdown(
         nvidia_compute_ratio,
         device="NVIDIA A100-PCIE-40GB",
+        num_baseline_models=num_baseline_models,
         color="green",
         is_baseline=baseline == "nvidia",
     )


### PR DESCRIPTION
Closes https://github.com/groq/mlagility/issues/197

This PR:
* Make sure dashboard clearly shows the reference number of models as part of the bar chart #197
* Makes it clear that Groq numbers are estimated