### PR TITLE
Add Pytorch eager + Pytorch 2.x Compiled runtimes for x86

### DIFF
--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -8,13 +8,17 @@ MLAgility's tools currently support the following combinations of runtimes and d
 
 <span id="devices-runtimes-table">
 
-| Device Type | Device arg | Runtime      | Specific Devices                                         |
-| ----------- | ---------- | ------------ | -------------------------------------------------------- |
-| Nvidia GPU  | nvidia     | TensorRT     | Any Nvidia GPU supported by TensorRT >= 8.5.2            |
-| x86 CPU     | x86        | ONNX Runtime | Any Intel or AMD CPU supported by ONNX Runtime >= 1.13.1 |
-| Groq        | groq       | GroqFlow     | GroqChip1                                                |
-
+| Device Type | Device arg | Runtime                                                            | Device arg                 | Specific Devices                              |
+| ----------- | ---------- | ------------------------------------------------------------------ | -------------------------- | --------------------------------------------- |
+| Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                               | trt                        | Any Nvidia GPU supported by TensorRT          |
+| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch, Pytoch 2.x Compiled<sup>*</sup> | ort, torch, torch_compiled | Any Intel or AMD CPU supported by the runtime |
+| Groq        | groq       | GroqFlow                                                           | groqflow                   | GroqChip1                                     |
 </span>
+
+<sup>†</sup> Requires TensorRT >= 8.5.2  
+<sup>‡</sup> Requires ONNX Runtime >= 1.13.1  
+<sup>†</sup> Requires Pytorch >= 2.0.0
+
 
 # Table of Contents
 
@@ -262,9 +266,7 @@ Also available as API arguments:
 - `benchmark_script(backend=...)`
 - `benchmark_model(backend=...)`
 
-### Runtime (future feature)
-
-*Future feature, not yet implemented.* 
+### Runtime
 
 Indicates which software runtime should be used for the benchmark (e.g., ONNX Runtime vs. TensorRT for a GPU benchmark).
 
@@ -277,14 +279,16 @@ Each device type has its own default runtime, as indicated below. Valid values i
 - `ort`: ONNX Runtime (default for `x86` device type).
 - `trt`: Nvidia TensorRT (default for `nvidia` device type).
 - `groq`: GroqFlow (default for `groq` device type).
-- [future] `pytorch1`: PyTorch 1.x-style eager execution.
-- [future] `pytorch2`: PyTorch 2.x-style compiled graph execution.
+- `torch`: PyTorch default execution.
+- `torch_compiled`: PyTorch 2.x-style compiled graph execution.
 - [future] `ort-*`: Specific [ONNX Runtime execution providers]
 (#https://onnxruntime.ai/docs/execution-providers/)
 
-In the future this will also be available as API arguments: 
-- `benchmark_script(runtime=...)`
+This feature is also be available as an API argument: 
+- `benchmark_script(runtimes=...)`
 - `benchmark_model(runtime=...)`
+
+> _Note_: One runtime must be specified for each device. If no runtimes are specified, default values are used.
 
 # Additional Commands and Options
 

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -11,7 +11,7 @@ MLAgility's tools currently support the following combinations of runtimes and d
 | Device Type | Device arg | Runtime                                                            | Runtime arg                | Specific Devices                              |
 | ----------- | ---------- | ------------------------------------------------------------------ | -------------------------- | --------------------------------------------- |
 | Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                               | trt                        | Any Nvidia GPU supported by TensorRT          |
-| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch, Pytoch 2.x Compiled<sup>*</sup> | ort, torch, torch_compiled | Any Intel or AMD CPU supported by the runtime |
+| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch, Pytoch 2.x Compiled<sup>*</sup> | ort, torch, torch-compiled | Any Intel or AMD CPU supported by the runtime |
 | Groq        | groq       | GroqFlow                                                           | groqflow                   | GroqChip1                                     |
 </span>
 
@@ -280,7 +280,7 @@ Each device type has its own default runtime, as indicated below. Valid values i
 - `trt`: Nvidia TensorRT (default for `nvidia` device type).
 - `groq`: GroqFlow (default for `groq` device type).
 - `torch`: PyTorch default execution.
-- `torch_compiled`: PyTorch 2.x-style compiled graph execution.
+- `torch-compiled`: PyTorch 2.x-style compiled graph execution.
 - [future] `ort-*`: Specific [ONNX Runtime execution providers]
 (#https://onnxruntime.ai/docs/execution-providers/)
 

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -8,16 +8,17 @@ MLAgility's tools currently support the following combinations of runtimes and d
 
 <span id="devices-runtimes-table">
 
-| Device Type | Device arg | Runtime                                                            | Runtime arg                | Specific Devices                              |
-| ----------- | ---------- | ------------------------------------------------------------------ | -------------------------- | --------------------------------------------- |
-| Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                               | trt                        | Any Nvidia GPU supported by TensorRT          |
-| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch, Pytoch 2.x Compiled<sup>*</sup> | ort, torch, torch-compiled | Any Intel or AMD CPU supported by the runtime |
-| Groq        | groq       | GroqFlow                                                           | groqflow                   | GroqChip1                                     |
+| Device Type | Device arg | Runtime                                                                         | Runtime arg                | Specific Devices                              |
+| ----------- | ---------- | ------------------------------------------------------------------------------- | -------------------------- | --------------------------------------------- |
+| Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                                            | trt                        | Any Nvidia GPU supported by TensorRT          |
+| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch<sup>§</sup>, Pytoch 2.x Compiled<sup>*§</sup> | ort, torch, torch-compiled | Any Intel or AMD CPU supported by the runtime |
+| Groq        | groq       | GroqFlow                                                                        | groqflow                   | GroqChip1                                     |
 </span>
 
 <sup>†</sup> Requires TensorRT >= 8.5.2  
 <sup>‡</sup> Requires ONNX Runtime >= 1.13.1  
-<sup>*</sup> Requires Pytorch >= 2.0.0
+<sup>*</sup> Requires Pytorch >= 2.0.0  
+<sup>§</sup> Only available on `local` backend
 
 
 # Table of Contents
@@ -258,6 +259,7 @@ Valid values:
 > _Note_: while `--backend remote` is implemented, and we use it for our own purposes, it has some limitations and we do not recommend using it. The limitations are:
 >- Currently requires Okta SFT authentication, which not everyone will have.
 >- Not covered by our automatic testing yet.
+>- Not all runtimes may be supported when using the remote backend as discussed in the runtime section.
 
 Also available as API arguments:
 - `benchmark_script(backend=...)`
@@ -265,7 +267,7 @@ Also available as API arguments:
 
 ### Runtimes
 
-Indicates which software runtime should be used for the benchmark (e.g., ONNX Runtime vs. TensorRT for a GPU benchmark).
+Indicates which software runtime(s) should be used for the benchmark (e.g., ONNX Runtime vs. TensorRT for a GPU benchmark).
 
 Usage:
 - `benchit benchmark INPUT_FILES --runtime SW`
@@ -280,10 +282,11 @@ Each device type has its own default runtime, as indicated below.
 - Valid runtimes for `groq` device
   - `groq`: GroqFlow (default).
 
-
 This feature is also be available as an API argument: 
-- `benchmark_script(runtimes=...)`
+- `benchmark_script(runtimes=[...])`
 - `benchmark_model(runtime=...)`
+
+> _Note_: `torch` and `torch-compiled` are not available whe using the `remote` backend.
 
 # Additional Commands and Options
 

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -275,7 +275,7 @@ Usage:
 Each device type has its own default runtime, as indicated below.
 - Valid runtimes for `x86` device
   - `ort`: ONNX Runtime (default).
-  - `torch`: PyTorch eager execution.
+  - `torch`: PyTorch default execution (either eager or graph mode, depending on how your model has been written).
   - `torch-compiled`: PyTorch 2.x-style compiled graph execution.
 - Valid runtimes for `nvidia` device
   - `trt`: Nvidia TensorRT (default).

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -17,7 +17,7 @@ MLAgility's tools currently support the following combinations of runtimes and d
 
 <sup>†</sup> Requires TensorRT >= 8.5.2  
 <sup>‡</sup> Requires ONNX Runtime >= 1.13.1  
-<sup>†</sup> Requires Pytorch >= 2.0.0
+<sup>*</sup> Requires Pytorch >= 2.0.0
 
 
 # Table of Contents
@@ -279,7 +279,7 @@ Each device type has its own default runtime, as indicated below. Valid values i
 - `ort`: ONNX Runtime (default for `x86` device type).
 - `trt`: Nvidia TensorRT (default for `nvidia` device type).
 - `groq`: GroqFlow (default for `groq` device type).
-- `torch`: PyTorch default execution.
+- `torch`: PyTorch eager execution.
 - `torch-compiled`: PyTorch 2.x-style compiled graph execution.
 - [future] `ort-*`: Specific [ONNX Runtime execution providers]
 (#https://onnxruntime.ai/docs/execution-providers/)

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -221,13 +221,11 @@ The following arguments are used to configure `benchit` and the APIs to target a
 
 ### Devices
 
-Specify a list of device types that will be used for benchmarking.
+Specify a device type that will be used for benchmarking.
 
 Usage:
-- `benchit benchmark INPUT_FILES --devices TYPE`
+- `benchit benchmark INPUT_FILES --device TYPE`
   - Benchmark the model(s) in `INPUT_FILES` on a locally installed device of type `TYPE` (eg, a locally installed Nvidia device).
-- `benchit benchmark INPUT_FILES --devices [TYPE ...]`
-  - Benchmark the model(s) in `INPUT_FILES` across all provided device types.
 
 Valid values of `TYPE` include:
 - `x86` (default): Intel and AMD x86 CPUs.
@@ -239,9 +237,8 @@ Valid values of `TYPE` include:
 >  - For example, if you specify `--device nvidia` on a machine with an Nvidia A100 40GB installed, then MLAgility will use that Nvidia A100 40GB device.
 
 Also available as API arguments: 
-- `benchmark_script(devices=[...])`
+- `benchmark_script(device=...)`
 - `benchmark_model(device=...)`.
-    - _Note_: A single call to `benchmark_model()` only supports benchmarking on one device at a time, so you must call the API once per device.
 
 > For a detailed example, see the [CLI Nvidia tutorial](https://github.com/groq/mlagility/blob/main/examples/cli/readme.md#nvidia-benchmarking).
 
@@ -266,29 +263,27 @@ Also available as API arguments:
 - `benchmark_script(backend=...)`
 - `benchmark_model(backend=...)`
 
-### Runtime
+### Runtimes
 
 Indicates which software runtime should be used for the benchmark (e.g., ONNX Runtime vs. TensorRT for a GPU benchmark).
 
 Usage:
 - `benchit benchmark INPUT_FILES --runtime SW`
 
-> _Note_: We will add support for user-selected runtimes in the future, when `benchit` supports multiple runtimes per device. At the time of this writing, there is a 1:1 mapping between all supported runtimes and devices, so there is no need for the `--runtime` argument yet.
+Each device type has its own default runtime, as indicated below.
+- Valid runtimes for `x86` device
+  - `ort`: ONNX Runtime (default).
+  - `torch`: PyTorch eager execution.
+  - `torch-compiled`: PyTorch 2.x-style compiled graph execution.
+- Valid runtimes for `nvidia` device
+  - `trt`: Nvidia TensorRT (default).
+- Valid runtimes for `groq` device
+  - `groq`: GroqFlow (default).
 
-Each device type has its own default runtime, as indicated below. Valid values include:
-- `ort`: ONNX Runtime (default for `x86` device type).
-- `trt`: Nvidia TensorRT (default for `nvidia` device type).
-- `groq`: GroqFlow (default for `groq` device type).
-- `torch`: PyTorch eager execution.
-- `torch-compiled`: PyTorch 2.x-style compiled graph execution.
-- [future] `ort-*`: Specific [ONNX Runtime execution providers]
-(#https://onnxruntime.ai/docs/execution-providers/)
 
 This feature is also be available as an API argument: 
 - `benchmark_script(runtimes=...)`
 - `benchmark_model(runtime=...)`
-
-> _Note_: One runtime must be specified for each device. If no runtimes are specified, default values are used.
 
 # Additional Commands and Options
 

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -8,11 +8,11 @@ MLAgility's tools currently support the following combinations of runtimes and d
 
 <span id="devices-runtimes-table">
 
-| Device Type | Device arg | Runtime                                                                         | Runtime arg                | Specific Devices                              |
-| ----------- | ---------- | ------------------------------------------------------------------------------- | -------------------------- | --------------------------------------------- |
-| Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                                            | trt                        | Any Nvidia GPU supported by TensorRT          |
-| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch<sup>§</sup>, Pytoch 2.x Compiled<sup>*§</sup> | ort, torch, torch-compiled | Any Intel or AMD CPU supported by the runtime |
-| Groq        | groq       | GroqFlow                                                                        | groqflow                   | GroqChip1                                     |
+| Device Type | Device arg | Runtime                                                                               | Runtime arg                      | Specific Devices                              |
+| ----------- | ---------- | ------------------------------------------------------------------------------------- | -------------------------------- | --------------------------------------------- |
+| Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                                                  | trt                              | Any Nvidia GPU supported by TensorRT          |
+| x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch Eager<sup>§</sup>, Pytoch 2.x Compiled<sup>*§</sup> | ort, torch-eager, torch-compiled | Any Intel or AMD CPU supported by the runtime |
+| Groq        | groq       | GroqFlow                                                                              | groq                             | GroqChip1                                     |
 </span>
 
 <sup>†</sup> Requires TensorRT >= 8.5.2  
@@ -275,8 +275,8 @@ Usage:
 Each device type has its own default runtime, as indicated below.
 - Valid runtimes for `x86` device
   - `ort`: ONNX Runtime (default).
-  - `torch`: PyTorch default execution (either eager or graph mode, depending on how your model has been written).
-  - `torch-compiled`: PyTorch 2.x-style compiled graph execution.
+  - `torch-eager`: PyTorch eager execution.
+  - `torch-compiled`: PyTorch 2.x-style compiled graph execution using TorchInductor.
 - Valid runtimes for `nvidia` device
   - `trt`: Nvidia TensorRT (default).
 - Valid runtimes for `groq` device
@@ -286,7 +286,7 @@ This feature is also be available as an API argument:
 - `benchmark_script(runtimes=[...])`
 - `benchmark_model(runtime=...)`
 
-> _Note_: `torch` and `torch-compiled` are not available whe using the `remote` backend.
+> _Note_: `torch-eager` and `torch-compiled` are not available whe using the `remote` backend.
 
 # Additional Commands and Options
 

--- a/docs/tools_user_guide.md
+++ b/docs/tools_user_guide.md
@@ -8,7 +8,7 @@ MLAgility's tools currently support the following combinations of runtimes and d
 
 <span id="devices-runtimes-table">
 
-| Device Type | Device arg | Runtime                                                            | Device arg                 | Specific Devices                              |
+| Device Type | Device arg | Runtime                                                            | Runtime arg                | Specific Devices                              |
 | ----------- | ---------- | ------------------------------------------------------------------ | -------------------------- | --------------------------------------------- |
 | Nvidia GPU  | nvidia     | TensorRT<sup>†</sup>                                               | trt                        | Any Nvidia GPU supported by TensorRT          |
 | x86 CPU     | x86        | ONNX Runtime<sup>‡</sup>, Pytorch, Pytoch 2.x Compiled<sup>*</sup> | ort, torch, torch_compiled | Any Intel or AMD CPU supported by the runtime |

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -203,7 +203,7 @@ def call_benchit(
                 cache_dir=tracer_args.cache_dir,
                 build_name=build_name,
                 parent_key="performance",
-                key=perf.device,
+                key=f"{perf.device} ({perf.runtime} v{perf.runtime_version})",
                 value=vars(perf),
             )
 

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -35,6 +35,7 @@ class TracerArgs:
     input: str
     device: str
     backend: str
+    runtime: str
     actions: List[Action]
     lean_cache: bool
     targets: List[str]
@@ -122,6 +123,7 @@ def call_benchit(
             inputs,
             device=tracer_args.device,
             backend=tracer_args.backend,
+            runtime=tracer_args.runtime,
             build_name=build_name,
             cache_dir=tracer_args.cache_dir,
             build_only=Action.BENCHMARK not in tracer_args.actions,

--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -174,29 +174,38 @@ def call_benchit(
         build_state = build.load_state(
             cache_dir=tracer_args.cache_dir, build_name=build_name
         )
-        onnx_ops_counter = util.get_onnx_ops_list(build_state.converted_onnx_file)
-        onnx_model_info = util.populate_onnx_model_info(build_state.converted_onnx_file)
-        onnx_input_dimensions = util.onnx_input_dimensions(
-            build_state.converted_onnx_file
-        )
-        # Stats that we want to save into the build's mlagility_stats.yaml file
+
+        # ONNX stats that we want to save into the build's mlagility_stats.yaml file
         # so that they can be easily accessed by the report command later
-        filesystem.save_stat(tracer_args.cache_dir, build_name, "hash", model_info.hash)
-        filesystem.save_stat(
-            tracer_args.cache_dir, build_name, "parameters", model_info.params
-        )
-        filesystem.save_stat(
-            tracer_args.cache_dir, build_name, "onnx_ops_counter", onnx_ops_counter
-        )
-        filesystem.save_stat(
-            tracer_args.cache_dir, build_name, "onnx_model_information", onnx_model_info
-        )
-        filesystem.save_stat(
-            tracer_args.cache_dir,
-            build_name,
-            "onnx_input_dimensions",
-            onnx_input_dimensions,
-        )
+        if tracer_args.runtime not in ["torch-eager", "torch-compiled"]:
+            onnx_ops_counter = util.get_onnx_ops_list(build_state.converted_onnx_file)
+            onnx_model_info = util.populate_onnx_model_info(
+                build_state.converted_onnx_file
+            )
+            onnx_input_dimensions = util.onnx_input_dimensions(
+                build_state.converted_onnx_file
+            )
+            filesystem.save_stat(
+                tracer_args.cache_dir, build_name, "hash", model_info.hash
+            )
+            filesystem.save_stat(
+                tracer_args.cache_dir, build_name, "parameters", model_info.params
+            )
+            filesystem.save_stat(
+                tracer_args.cache_dir, build_name, "onnx_ops_counter", onnx_ops_counter
+            )
+            filesystem.save_stat(
+                tracer_args.cache_dir,
+                build_name,
+                "onnx_model_information",
+                onnx_model_info,
+            )
+            filesystem.save_stat(
+                tracer_args.cache_dir,
+                build_name,
+                "onnx_input_dimensions",
+                onnx_input_dimensions,
+            )
 
         if perf:
             filesystem.add_sub_stat(

--- a/src/mlagility/analysis/status.py
+++ b/src/mlagility/analysis/status.py
@@ -84,7 +84,7 @@ def print_model(
     if model_info.performance:
         printing.log(f"{ident}\tStatus:\t\t")
         printing.logn(
-            f"Model successfully benchmarked on {model_info.performance.device}",
+            f"Successfully benchmarked on {model_info.performance.device} ({model_info.performance.runtime} v{model_info.performance.runtime_version})",
             c=model_info.status_message_color,
         )
         printing.logn(

--- a/src/mlagility/analysis/util.py
+++ b/src/mlagility/analysis/util.py
@@ -86,12 +86,11 @@ def populate_onnx_model_info(onnx_model) -> Dict:
         printing.log_warning(f"Failed to get ONNX ops list from {onnx_model}: {str(e)}")
         result_dict.update({"error": "ONNX model analysis failed"})
         return result_dict
+    # pylint: disable=E1101
     result_dict.update(
         {
             "ir_version": getattr(model, "ir_version", None),
-            "opset": getattr(
-                model.opset_import[-1], "version", None
-            ),  # pylint: disable=E1101
+            "opset": getattr(model.opset_import[-1], "version", None),
             "size on disk (KiB)": round(
                 model.SerializeToString().__sizeof__() / 1024, 4
             ),

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -14,7 +14,7 @@ ORT_EXECUTION_SCRIPT = "run_ort_model.py"
 TRT_BENCHMARKING_SCRIPT = "execute_trt.py"
 SUPPORTED_DEVICES = {
     "x86": ["ort", "torch", "torch-compiled"],
-    "groq": ["groqflow"],
+    "groq": ["groq"],
     "nvidia": ["trt"],
 }
 DEFAULT_RUNTIME = 0

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -217,7 +217,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
             msg = "No NVIDIA GPUs available on the remote machine"
             raise exp.ModelRuntimeError(msg)
         files_to_transfer = [TRT_BENCHMARKING_SCRIPT]
-    elif device_type == "x86":
+    elif device_type in ["x86", "x86_pytorch"]:
         # Check if x86_64 CPU is available remotely
         stdout, exit_code = exec_command(client, "uname -i")
         if stdout != "x86_64" or exit_code == 1:
@@ -244,7 +244,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
         files_to_transfer = ["execute.py"]
     else:
         raise ValueError(
-            "Only 'nvidia', 'x86' and 'groqchip' are supported."
+            "Only 'nvidia', 'x86', 'x86_pytorch', and 'groqchip' are supported."
             f"But received {device_type}"
         )
 

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -13,7 +13,7 @@ ORT_BENCHMARKING_SCRIPT = "setup_ort.py"
 ORT_EXECUTION_SCRIPT = "run_ort_model.py"
 TRT_BENCHMARKING_SCRIPT = "execute_trt.py"
 SUPPORTED_DEVICES = {
-    "x86": ["ort", "torch", "torch-compiled"],
+    "x86": ["ort", "torch-eager", "torch-compiled"],
     "groq": ["groq"],
     "nvidia": ["trt"],
 }

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -12,6 +12,11 @@ import onnxflow.common.build as build
 ORT_BENCHMARKING_SCRIPT = "setup_ort.py"
 ORT_EXECUTION_SCRIPT = "run_ort_model.py"
 TRT_BENCHMARKING_SCRIPT = "execute_trt.py"
+SUPPORTED_DEVICES = {
+    "x86": ["ort", "torch", "torch_compiled"],
+    "groq": ["groqflow"],
+    "nvidia": ["trt"],
+}
 
 
 class BenchmarkPaths:
@@ -217,7 +222,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
             msg = "No NVIDIA GPUs available on the remote machine"
             raise exp.ModelRuntimeError(msg)
         files_to_transfer = [TRT_BENCHMARKING_SCRIPT]
-    elif device_type in ["x86", "x86_pytorch", "x86_pytorch_compiled"]:
+    elif device_type in ["x86"]:
         # Check if x86_64 CPU is available remotely
         stdout, exit_code = exec_command(client, "uname -i")
         if stdout != "x86_64" or exit_code == 1:
@@ -244,7 +249,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
         files_to_transfer = ["execute.py"]
     else:
         raise ValueError(
-            "Only 'nvidia', 'x86', 'x86_pytorch', x86_pytorch_compiled, and 'groqchip' are supported."
+            "Only 'nvidia', 'x86', and 'groqchip' are supported."
             f"But received {device_type}"
         )
 

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -13,7 +13,7 @@ ORT_BENCHMARKING_SCRIPT = "setup_ort.py"
 ORT_EXECUTION_SCRIPT = "run_ort_model.py"
 TRT_BENCHMARKING_SCRIPT = "execute_trt.py"
 SUPPORTED_DEVICES = {
-    "x86": ["ort", "torch", "torch_compiled"],
+    "x86": ["ort", "torch", "torch-compiled"],
     "groq": ["groqflow"],
     "nvidia": ["trt"],
 }

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -217,7 +217,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
             msg = "No NVIDIA GPUs available on the remote machine"
             raise exp.ModelRuntimeError(msg)
         files_to_transfer = [TRT_BENCHMARKING_SCRIPT]
-    elif device_type in ["x86", "x86_pytorch"]:
+    elif device_type in ["x86", "x86_pytorch", "x86_pytorch_compiled"]:
         # Check if x86_64 CPU is available remotely
         stdout, exit_code = exec_command(client, "uname -i")
         if stdout != "x86_64" or exit_code == 1:
@@ -244,7 +244,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
         files_to_transfer = ["execute.py"]
     else:
         raise ValueError(
-            "Only 'nvidia', 'x86', 'x86_pytorch', and 'groqchip' are supported."
+            "Only 'nvidia', 'x86', 'x86_pytorch', x86_pytorch_compiled, and 'groqchip' are supported."
             f"But received {device_type}"
         )
 

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -222,7 +222,7 @@ def setup_remote_host(client, device_type: str, output_dir: str) -> None:
             msg = "No NVIDIA GPUs available on the remote machine"
             raise exp.ModelRuntimeError(msg)
         files_to_transfer = [TRT_BENCHMARKING_SCRIPT]
-    elif device_type in ["x86"]:
+    elif device_type == "x86":
         # Check if x86_64 CPU is available remotely
         stdout, exit_code = exec_command(client, "uname -i")
         if stdout != "x86_64" or exit_code == 1:

--- a/src/mlagility/api/devices.py
+++ b/src/mlagility/api/devices.py
@@ -17,6 +17,7 @@ SUPPORTED_DEVICES = {
     "groq": ["groqflow"],
     "nvidia": ["trt"],
 }
+DEFAULT_RUNTIME = 0
 
 
 class BenchmarkPaths:

--- a/src/mlagility/api/execute_trt.py
+++ b/src/mlagility/api/execute_trt.py
@@ -12,6 +12,9 @@ import json
 # Set a 15 minutes timeout for all docker commands
 TIMEOUT = 900
 
+TRT_VERSION = "23.03-py3"
+
+
 def run(
     output_dir: str,
     onnx_file: str,
@@ -22,8 +25,8 @@ def run(
     # Latest docker image can be found here:
     # https://catalog.ngc.nvidia.com/orgs/nvidia/containers/tensorrt/tags
     # GroqFlow maintainers to keep this up to date with the latest version of release container
-    latest_trt_docker = "nvcr.io/nvidia/tensorrt:23.03-py3"
-    docker_name = "tensorrt23.03"
+    latest_trt_docker = f"nvcr.io/nvidia/tensorrt:{TRT_VERSION}"
+    docker_name = f"tensorrt{TRT_VERSION}"
 
     # docker run args:
     # "--gpus all" - use all gpus available
@@ -36,7 +39,9 @@ def run(
     # "--onnx=<path>" - path to the onnx model in the mounted file
     # "--fp16" - enable execution in fp16 mode on tensorrt
     # "--iterations=<int>" - number of iterations to run on tensorrt
-    docker_exec_args = f"trtexec --onnx={onnx_file} --fp16 --iterations={num_iterations}"
+    docker_exec_args = (
+        f"trtexec --onnx={onnx_file} --fp16 --iterations={num_iterations}"
+    )
 
     run_command = (
         f"sudo docker run --name {docker_name} {docker_run_args} {latest_trt_docker}"

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -84,6 +84,8 @@ def benchmark_model(
                     mean_latency=groq_perf.latency,
                     device="GroqChip1",
                     device_type="groq",
+                    runtime="groq",
+                    runtime_version=gmodel.state.groqflow_version,
                     build_name=gmodel.state.config.build_name,
                 )
 
@@ -138,7 +140,7 @@ def benchmark_model(
                 sequence=sequence,
             )
 
-            torch_version = torch.__version__
+            torch_version = str(torch.__version__)
             if runtime == "torch-compiled":
                 clean_torch_version = torch_version.split("+")[0]
                 if version.parse(clean_torch_version) < version.parse("2.0.0"):
@@ -169,21 +171,13 @@ def benchmark_model(
                     1 / (np.sum(per_iteration_latency) / num_iterations)
                 )
 
-                if runtime == "torch":
-                    device_name = (
-                        get_cpu_specs()["CPU Name"] + f" (Pytorch {torch_version})"
-                    )
-                else:
-                    device_name = (
-                        get_cpu_specs()["CPU Name"]
-                        + f" (Pytorch {torch_version} Compiled)"
-                    )
-
                 return MeasuredPerformance(
                     mean_latency=mean_latency_ms,
                     throughput=throughput_ips,
-                    device=device_name,
+                    device=get_cpu_specs()["CPU Name"],
                     device_type=device,
+                    runtime=runtime,
+                    runtime_version=torch_version,
                     build_name=build_name,
                 )
 

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -123,7 +123,7 @@ def benchmark_model(
                 )
                 perf = cpu_model.benchmark(backend=backend)
 
-        elif device == "x86" and runtime in ["torch", "torch_compiled"]:
+        elif device == "x86" and runtime in ["torch", "torch-compiled"]:
 
             # Create cache folder with stats file
             # Although building with an empty sequence is possible, we don't want
@@ -139,7 +139,7 @@ def benchmark_model(
             )
 
             torch_version = torch.__version__
-            if runtime == "torch_compiled":
+            if runtime == "torch-compiled":
                 clean_torch_version = torch_version.split("+")[0]
                 if version.parse(clean_torch_version) < version.parse("2.0.0"):
                     BenchmarkException(

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -1,11 +1,10 @@
 import sys
 import os
 import time
-import json
-import torch
-import numpy as np
 from statistics import mean
 from typing import Any, Dict, Optional, List
+import torch
+import numpy as np
 from onnxflow import build_model
 from onnxflow.justbuildit.stage import Sequence
 import onnxflow.common.printing as printing

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -8,6 +8,7 @@ from packaging import version
 import numpy as np
 from onnxflow import build_model
 from onnxflow.justbuildit.stage import Sequence
+import onnxflow.common.exceptions as exp
 import onnxflow.common.printing as printing
 import onnxflow.common.build as build
 import onnxflow.justbuildit.ignition as ignition
@@ -130,7 +131,12 @@ def benchmark_model(
 
         elif device == "x86" and runtime in ["torch-eager", "torch-compiled"]:
 
-            # ENSURE THIS IS NOT AN ONNX MODEL
+            # Ensure we have the correct model type
+            model_type = ignition.identify_model_type(model)
+            if model_type != build.ModelType.PYTORCH:
+                raise exp.IntakeError(
+                    f"Only Pytorch models are valid when runtime is {runtime}"
+                )
 
             # Benchmarking using `torch-eager` and `torch-compiled` does not require
             # converting the model to ONNX. Here, we simply create a state in order to
@@ -146,7 +152,7 @@ def benchmark_model(
                     rebuild=rebuild,
                     cache_dir=cache_dir,
                     config=config,
-                    model_type=build.ModelType.PYTORCH,
+                    model_type=model_type,
                 )
                 state.save()
 

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -149,20 +149,25 @@ def benchmark_model(
                         )
                     )
 
-                model = torch.compile(model)
+            # Compile model if needed
+            selected_model = (
+                torch.compile(model) if runtime == "torch-compiled" else model
+            )
 
             if not build_only:
-                repetitions = 100
-                total_time = [0] * repetitions
-                for idx in range(repetitions):
+                num_iterations = 100
+                per_iteration_latency = [0] * num_iterations
+                for idx in range(num_iterations):
                     start_time = time.process_time()
-                    model(**inputs)
+                    selected_model(**inputs)
                     end_time = time.process_time()
-                    total_time[idx] = end_time - start_time
+                    per_iteration_latency[idx] = end_time - start_time
 
-                # Calculate perf from total_time
-                mean_latency_ms = mean(total_time) * 1000
-                throughput_ips = float(1 / (np.sum(total_time) / repetitions))
+                # Calculate perf from per_iteration_latency
+                mean_latency_ms = mean(per_iteration_latency) * 1000
+                throughput_ips = float(
+                    1 / (np.sum(per_iteration_latency) / num_iterations)
+                )
 
                 if runtime == "torch":
                     device_name = (

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -1,6 +1,6 @@
 import sys
 import os
-import time
+from timeit import default_timer as timer
 from statistics import mean
 from typing import Any, Dict, Optional, List
 import torch
@@ -158,9 +158,9 @@ def benchmark_model(
                 num_iterations = 100
                 per_iteration_latency = [0] * num_iterations
                 for idx in range(num_iterations):
-                    start_time = time.process_time()
+                    start_time = timer()
                     selected_model(**inputs)
-                    end_time = time.process_time()
+                    end_time = timer()
                     per_iteration_latency[idx] = end_time - start_time
 
                 # Calculate perf from per_iteration_latency

--- a/src/mlagility/api/model_api.py
+++ b/src/mlagility/api/model_api.py
@@ -125,7 +125,7 @@ def benchmark_model(
                 )
                 perf = cpu_model.benchmark(backend=backend)
 
-        elif device == "x86" and runtime in ["torch", "torch-compiled"]:
+        elif device == "x86" and runtime in ["torch-eager", "torch-compiled"]:
 
             # Create cache folder with stats file
             # Although building with an empty sequence is possible, we don't want

--- a/src/mlagility/api/ortmodel.py
+++ b/src/mlagility/api/ortmodel.py
@@ -12,6 +12,7 @@ class ORTModel:
         self.cache_dir = cache_dir
         self.build_name = build_name
         self.device_type = "x86"
+        self.runtime = "ort"
 
     def benchmark(
         self, repetitions: int = 100, backend: str = "local"
@@ -84,5 +85,7 @@ class ORTModel:
             throughput=self.throughput,
             device=self.device_name,
             device_type=self.device_type,
+            runtime=self.runtime,
+            runtime_version=self._get_stat("OnnxRuntime Version"),
             build_name=self.build_name,
         )

--- a/src/mlagility/api/performance.py
+++ b/src/mlagility/api/performance.py
@@ -7,6 +7,8 @@ class MeasuredPerformance:
     throughput: float
     mean_latency: float
     device: str
+    runtime: str
+    runtime_version: str
     device_type: str
     build_name: str
     throughput_units: str = "inferences per second (IPS)"
@@ -14,8 +16,8 @@ class MeasuredPerformance:
 
     def print(self):
         printing.log_info(
-            f"\nPerformance of build {self.build_name} on {self.device_type} device "
-            f"{self.device} is:"
+            f"\nPerformance of build {self.build_name} on {self.device} "
+            f"({self.runtime} v{self.runtime_version}) is:"
         )
         print(f"\tMean Latency: {self.mean_latency:.3f} {self.latency_units}")
         print(f"\tThroughput: {self.throughput:.1f} {self.throughput_units}")

--- a/src/mlagility/api/script_api.py
+++ b/src/mlagility/api/script_api.py
@@ -11,7 +11,7 @@ import mlagility.cli.slurm as slurm
 import mlagility.common.filesystem as filesystem
 import mlagility.common.labels as labels_library
 from mlagility.api.model_api import benchmark_model
-from mlagility.api.devices import SUPPORTED_DEVICES
+from mlagility.api.devices import SUPPORTED_DEVICES, DEFAULT_RUNTIME
 from mlagility.analysis.analysis import (
     evaluate_script,
     TracerArgs,
@@ -107,7 +107,7 @@ def benchmark_script(
     if devices is None:
         devices = ["x86"]
     if runtimes is None:
-        runtimes = [SUPPORTED_DEVICES["x86"][0]]
+        runtimes = [SUPPORTED_DEVICES["x86"][DEFAULT_RUNTIME]]
 
     # Force the user to specify a legal cache dir in NFS if they are using slurm
     if cache_dir == filesystem.DEFAULT_CACHE_DIR and use_slurm:

--- a/src/mlagility/api/script_api.py
+++ b/src/mlagility/api/script_api.py
@@ -84,7 +84,7 @@ def benchmark_script(
     cache_dir: str = filesystem.DEFAULT_CACHE_DIR,
     labels: List[str] = None,
     rebuild: Optional[str] = None,
-    devices: List[str] = None,
+    device: str = None,
     backend: str = "local",
     runtimes: List[str] = None,
     analyze_only: bool = False,
@@ -104,10 +104,10 @@ def benchmark_script(
 
     custom_sequence = load_sequence_from_file(sequence, use_slurm)
 
-    if devices is None:
-        devices = ["x86"]
+    if device is None:
+        device = "x86"
     if runtimes is None:
-        runtimes = [SUPPORTED_DEVICES["x86"][DEFAULT_RUNTIME]]
+        runtimes = [SUPPORTED_DEVICES[device][DEFAULT_RUNTIME]]
 
     # Force the user to specify a legal cache dir in NFS if they are using slurm
     if cache_dir == filesystem.DEFAULT_CACHE_DIR and use_slurm:
@@ -193,7 +193,7 @@ def benchmark_script(
         if os.environ.get("USING_SLURM") != "TRUE":
             db.add_script(filesystem.clean_script_name(script))
 
-        for runtime, device in zip(runtimes, devices):
+        for runtime in runtimes:
             if use_slurm:
                 slurm.run_benchit(
                     op="benchmark",
@@ -204,7 +204,7 @@ def benchmark_script(
                     groq_assembler_flags=groq_assembler_flags,
                     groq_num_chips=groq_num_chips,
                     groqview=groqview,
-                    devices=[device],
+                    device=device,
                     runtimes=[runtime],
                     max_depth=max_depth,
                     analyze_only=analyze_only,
@@ -260,7 +260,7 @@ def benchmark_files(
     cache_dir: str = filesystem.DEFAULT_CACHE_DIR,
     labels: List[str] = None,
     rebuild: Optional[str] = None,
-    devices: List[str] = None,
+    device: str = None,
     backend: str = "local",
     runtimes: List[str] = None,
     analyze_only: bool = False,
@@ -299,7 +299,7 @@ def benchmark_files(
             cache_dir=cache_dir,
             labels=labels,
             rebuild=rebuild,
-            devices=devices,
+            device=device,
             backend=backend,
             runtimes=runtimes,
             analyze_only=analyze_only,
@@ -329,7 +329,7 @@ def benchmark_files(
         else:
             onnx_sequence = load_sequence_from_file(sequence, use_slurm)
 
-        for runtime, device in zip(runtimes, devices):
+        for runtime in runtimes:
             benchmark_model(
                 model=onnx_file,
                 inputs=None,

--- a/src/mlagility/api/setup_ort.py
+++ b/src/mlagility/api/setup_ort.py
@@ -70,7 +70,10 @@ def run_docker_container(output_dir, docker_name, docker_image):
         return output
     except subprocess.CalledProcessError as e:
         logging.error(
-            f"Failed to start Docker container with command: {' '.join(cmd)} and error message: {e.stderr}"
+            (
+                f"Failed to start Docker container with command: "
+                f"{' '.join(cmd)} and error message: {e.stderr}"
+            )
         )
         raise
 

--- a/src/mlagility/api/setup_ort.py
+++ b/src/mlagility/api/setup_ort.py
@@ -171,7 +171,6 @@ def run(
                 logging.error(f"Failed to stop Docker container with exception: {e}")
 
     cpu_performance = get_cpu_specs()
-    cpu_performance["CPU Name"] += " (ORT)"
     cpu_performance["OnnxRuntime Version"] = str(ort_version)
     cpu_performance["Mean Latency(ms)"] = str(mean(perf_result) * 1000)
     cpu_performance["Throughput"] = str(BATCHSIZE / mean(perf_result))

--- a/src/mlagility/api/setup_ort.py
+++ b/src/mlagility/api/setup_ort.py
@@ -168,6 +168,7 @@ def run(
                 logging.error(f"Failed to stop Docker container with exception: {e}")
 
     cpu_performance = get_cpu_specs()
+    cpu_performance["CPU Name"] += " (ORT)"
     cpu_performance["OnnxRuntime Version"] = str(ort_version)
     cpu_performance["Mean Latency(ms)"] = str(mean(perf_result) * 1000)
     cpu_performance["Throughput"] = str(BATCHSIZE / mean(perf_result))

--- a/src/mlagility/api/trtmodel.py
+++ b/src/mlagility/api/trtmodel.py
@@ -3,6 +3,7 @@ import json
 import numpy as np
 import mlagility.api.devices as devices
 from mlagility.api.performance import MeasuredPerformance
+from mlagility.api.execute_trt import TRT_VERSION
 
 
 class TRTModel:
@@ -12,6 +13,7 @@ class TRTModel:
         self.cache_dir = cache_dir
         self.build_name = build_name
         self.device_type = "nvidia"
+        self.runtime = "trt"
 
     def benchmark(
         self, repetitions: int = 100, backend: str = "local"
@@ -83,5 +85,7 @@ class TRTModel:
             throughput=self.throughput,
             device=self.device_name,
             device_type=self.device_type,
+            runtime=self.runtime,
+            runtime_version=TRT_VERSION,
             build_name=self.build_name,
         )

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -442,39 +442,37 @@ def main():
             sys.argv.insert(1, "benchmark")
 
     args = parser.parse_args()
-    if args.func != benchmark_command:
-        args.func(args)
-
-    # Validate runtime arg
-    if args.runtimes:
-        if len(args.runtimes) != len(args.devices):
-            raise argparse.ArgumentError(
-                argparse_runtimes, "The number of devices and runtimes must match"
-            )
-        for device, runtime in zip(args.devices, args.runtimes):
-            if runtime not in SUPPORTED_DEVICES[device]:
+    if args.func == benchmark_command:
+        # Validate runtime arg
+        if args.runtimes:
+            if len(args.runtimes) != len(args.devices):
                 raise argparse.ArgumentError(
-                    argparse_runtimes,
-                    (
-                        f"Runtime '{runtime}' is not valid for device '{device}'. "
-                        f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
-                    ),
+                    argparse_runtimes, "The number of devices and runtimes must match"
                 )
-    # Assign default runtimes
-    else:
-        for device in args.devices:
-            args.runtimes.append(SUPPORTED_DEVICES[device][0])
+            for device, runtime in zip(args.devices, args.runtimes):
+                if runtime not in SUPPORTED_DEVICES[device]:
+                    raise argparse.ArgumentError(
+                        argparse_runtimes,
+                        (
+                            f"Runtime '{runtime}' is not valid for device '{device}'. "
+                            f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
+                        ),
+                    )
+        # Assign default runtimes
+        else:
+            for device in args.devices:
+                args.runtimes.append(SUPPORTED_DEVICES[device][0])
 
-    # Ensure that the selected runtimes are supported by the backend
-    if (
-        "torch" in args.runtimes or "torch_compiled" in args.runtimes
-    ) and args.backend == "remote":
-        raise argparse.ArgumentError(
-            argparse_backend,
-            (
-                "Remote backend is not available for 'torch' and 'torch_compiled' runtimes."
-            ),
-        )
+        # Ensure that the selected runtimes are supported by the backend
+        if (
+            "torch" in args.runtimes or "torch_compiled" in args.runtimes
+        ) and args.backend == "remote":
+            raise argparse.ArgumentError(
+                argparse_backend,
+                (
+                    "Remote backend is not available for 'torch' and 'torch_compiled' runtimes."
+                ),
+            )
     args.func(args)
 
 

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -6,6 +6,7 @@ import mlagility.common.filesystem as filesystem
 import mlagility.cli.report as report
 from mlagility.api.script_api import benchmark_files
 from mlagility.version import __version__ as mlagility_version
+from mlagility.api.devices import SUPPORTED_DEVICES
 
 
 class MyParser(argparse.ArgumentParser):
@@ -50,6 +51,7 @@ def benchmark_command(args):
         rebuild=args.rebuild,
         devices=args.devices,
         backend=args.backend,
+        runtimes=args.runtimes,
         analyze_only=args.analyze_only,
         build_only=args.build_only,
         resume=args.resume,
@@ -168,19 +170,23 @@ def main():
     benchmark_default_device = "x86"
     benchmark_parser.add_argument(
         "--devices",
-        choices=[
-            "x86",
-            "x86_pytorch",
-            "x86_pytorch_compiled",
-            "nvidia",
-            "groq",
-        ],
+        choices=SUPPORTED_DEVICES,
         nargs="+",
         dest="devices",
         help="Types(s) of hardware devices to be used for the benchmark "
         f'(defaults to ["{benchmark_default_device}"])',
         required=False,
         default=[benchmark_default_device],
+    )
+
+    argparse_runtimes = benchmark_parser.add_argument(
+        "--runtimes",
+        choices=sum(SUPPORTED_DEVICES.values(), []),
+        nargs="+",
+        dest="runtimes",
+        help="Runtime(s) for each of the selected devices",
+        required=False,
+        default=[],
     )
 
     benchmark_parser.add_argument(
@@ -436,6 +442,27 @@ def main():
             sys.argv.insert(1, "benchmark")
 
     args = parser.parse_args()
+
+    # Validate runtime arg
+    if args.runtimes:
+        if len(args.runtimes) != len(args.devices):
+            raise argparse.ArgumentError(
+                argparse_runtimes, "The number of devices and runtimes must match"
+            )
+        for device, runtime in zip(args.devices, args.runtimes):
+            if runtime not in SUPPORTED_DEVICES[device]:
+                raise argparse.ArgumentError(
+                    argparse_runtimes,
+                    (
+                        f"Runtime '{runtime}' is not valid for device '{device}'. "
+                        f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
+                    ),
+                )
+    # Assign default runtimes
+    else:
+        for device in args.devices:
+            args.runtimes.append(SUPPORTED_DEVICES[device][0])
+
     args.func(args)
 
 

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -170,6 +170,7 @@ def main():
         "--devices",
         choices=[
             "x86",
+            "x86_pytorch",
             "nvidia",
             "groq",
         ],

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -443,7 +443,7 @@ def main():
 
     args = parser.parse_args()
     if args.func == benchmark_command:
-        # Validate runtime arg
+        # Validate runtimes arg
         if args.runtimes:
             for runtime in args.runtimes:
                 if runtime not in SUPPORTED_DEVICES[args.device]:

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -465,12 +465,12 @@ def main():
 
         # Ensure that the selected runtimes are supported by the backend
         if (
-            "torch" in args.runtimes or "torch_compiled" in args.runtimes
+            "torch" in args.runtimes or "torch-compiled" in args.runtimes
         ) and args.backend == "remote":
             raise argparse.ArgumentError(
                 argparse_backend,
                 (
-                    "Remote backend is not available for 'torch' and 'torch_compiled' runtimes."
+                    "Remote backend is not available for 'torch' and 'torch-compiled' runtimes."
                 ),
             )
     args.func(args)

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -154,7 +154,7 @@ def main():
     )
 
     benchmark_default_backend = "local"
-    benchmark_parser.add_argument(
+    argparse_backend = benchmark_parser.add_argument(
         "--backend",
         choices=[
             "local",
@@ -442,28 +442,39 @@ def main():
             sys.argv.insert(1, "benchmark")
 
     args = parser.parse_args()
+    if args.func != benchmark_command:
+        args.func(args)
 
     # Validate runtime arg
-    if args.func == benchmark_command:
-        if args.runtimes:
-            if len(args.runtimes) != len(args.devices):
+    if args.runtimes:
+        if len(args.runtimes) != len(args.devices):
+            raise argparse.ArgumentError(
+                argparse_runtimes, "The number of devices and runtimes must match"
+            )
+        for device, runtime in zip(args.devices, args.runtimes):
+            if runtime not in SUPPORTED_DEVICES[device]:
                 raise argparse.ArgumentError(
-                    argparse_runtimes, "The number of devices and runtimes must match"
+                    argparse_runtimes,
+                    (
+                        f"Runtime '{runtime}' is not valid for device '{device}'. "
+                        f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
+                    ),
                 )
-            for device, runtime in zip(args.devices, args.runtimes):
-                if runtime not in SUPPORTED_DEVICES[device]:
-                    raise argparse.ArgumentError(
-                        argparse_runtimes,
-                        (
-                            f"Runtime '{runtime}' is not valid for device '{device}'. "
-                            f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
-                        ),
-                    )
-        # Assign default runtimes
-        else:
-            for device in args.devices:
-                args.runtimes.append(SUPPORTED_DEVICES[device][0])
+    # Assign default runtimes
+    else:
+        for device in args.devices:
+            args.runtimes.append(SUPPORTED_DEVICES[device][0])
 
+    # Ensure that the selected runtimes are supported by the backend
+    if (
+        "torch" in args.runtimes or "torch_compiled" in args.runtimes
+    ) and args.backend == "remote":
+        raise argparse.ArgumentError(
+            argparse_backend,
+            (
+                "Remote backend is not available for 'torch' and 'torch_compiled' runtimes."
+            ),
+        )
     args.func(args)
 
 

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -171,6 +171,7 @@ def main():
         choices=[
             "x86",
             "x86_pytorch",
+            "x86_pytorch_compiled",
             "nvidia",
             "groq",
         ],

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -444,24 +444,25 @@ def main():
     args = parser.parse_args()
 
     # Validate runtime arg
-    if args.runtimes:
-        if len(args.runtimes) != len(args.devices):
-            raise argparse.ArgumentError(
-                argparse_runtimes, "The number of devices and runtimes must match"
-            )
-        for device, runtime in zip(args.devices, args.runtimes):
-            if runtime not in SUPPORTED_DEVICES[device]:
+    if args.func == benchmark_command:
+        if args.runtimes:
+            if len(args.runtimes) != len(args.devices):
                 raise argparse.ArgumentError(
-                    argparse_runtimes,
-                    (
-                        f"Runtime '{runtime}' is not valid for device '{device}'. "
-                        f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
-                    ),
+                    argparse_runtimes, "The number of devices and runtimes must match"
                 )
-    # Assign default runtimes
-    else:
-        for device in args.devices:
-            args.runtimes.append(SUPPORTED_DEVICES[device][0])
+            for device, runtime in zip(args.devices, args.runtimes):
+                if runtime not in SUPPORTED_DEVICES[device]:
+                    raise argparse.ArgumentError(
+                        argparse_runtimes,
+                        (
+                            f"Runtime '{runtime}' is not valid for device '{device}'. "
+                            f"Expected one of the following: {SUPPORTED_DEVICES[device]}."
+                        ),
+                    )
+        # Assign default runtimes
+        else:
+            for device in args.devices:
+                args.runtimes.append(SUPPORTED_DEVICES[device][0])
 
     args.func(args)
 

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -460,12 +460,12 @@ def main():
 
         # Ensure that the selected runtimes are supported by the backend
         if (
-            "torch" in args.runtimes or "torch-compiled" in args.runtimes
+            "torch-eager" in args.runtimes or "torch-compiled" in args.runtimes
         ) and args.backend == "remote":
             raise argparse.ArgumentError(
                 argparse_backend,
                 (
-                    "Remote backend is not available for 'torch' and 'torch-compiled' runtimes."
+                    "Remote backend is not available for 'torch-eager' and 'torch-compiled' runtimes."
                 ),
             )
     args.func(args)

--- a/src/mlagility/cli/slurm.py
+++ b/src/mlagility/cli/slurm.py
@@ -68,7 +68,7 @@ def run_benchit(
     groq_assembler_flags: Optional[List[str]] = None,
     groq_num_chips: Optional[int] = None,
     groqview: Optional[bool] = None,
-    devices: Optional[List[str]] = None,
+    device: str = None,
     runtimes: Optional[List[str]] = None,
     max_depth: Optional[int] = None,
     analyze_only: Optional[bool] = None,
@@ -86,7 +86,7 @@ def run_benchit(
     assembler_flags_str = list_arg(groq_assembler_flags, "--groq-assembler-flags")
     num_chips_str = value_arg(groq_num_chips, "--groq-num-chips")
     groqview_str = bool_arg(groqview, "--groqview")
-    devices_str = list_arg(devices, "--devices")
+    device_str = device
     runtimes_str = list_arg(runtimes, "--runtimes")
     max_depth_str = value_arg(max_depth, "--max-depth")
     analyze_only_str = bool_arg(analyze_only, "--analyze-only")
@@ -96,7 +96,7 @@ def run_benchit(
     args = (
         f"{op} {script} {cache_dir_str}{rebuild_str}"
         f"{compiler_flags_str}{assembler_flags_str}{num_chips_str}{groqview_str}"
-        f"{devices_str}{runtimes_str}{max_depth_str}{analyze_only_str}"
+        f"{device_str}{runtimes_str}{max_depth_str}{analyze_only_str}"
         f"{build_only_str}{lean_cache_str}"
     )
 

--- a/src/mlagility/cli/slurm.py
+++ b/src/mlagility/cli/slurm.py
@@ -69,6 +69,7 @@ def run_benchit(
     groq_num_chips: Optional[int] = None,
     groqview: Optional[bool] = None,
     devices: Optional[List[str]] = None,
+    runtimes: Optional[List[str]] = None,
     max_depth: Optional[int] = None,
     analyze_only: Optional[bool] = None,
     build_only: Optional[bool] = None,
@@ -86,6 +87,7 @@ def run_benchit(
     num_chips_str = value_arg(groq_num_chips, "--groq-num-chips")
     groqview_str = bool_arg(groqview, "--groqview")
     devices_str = list_arg(devices, "--devices")
+    runtimes_str = list_arg(runtimes, "--runtimes")
     max_depth_str = value_arg(max_depth, "--max-depth")
     analyze_only_str = bool_arg(analyze_only, "--analyze-only")
     build_only_str = bool_arg(build_only, "--build-only")
@@ -94,7 +96,7 @@ def run_benchit(
     args = (
         f"{op} {script} {cache_dir_str}{rebuild_str}"
         f"{compiler_flags_str}{assembler_flags_str}{num_chips_str}{groqview_str}"
-        f"{devices_str}{max_depth_str}{analyze_only_str}"
+        f"{devices_str}{runtimes_str}{max_depth_str}{analyze_only_str}"
         f"{build_only_str}{lean_cache_str}"
     )
 

--- a/src/onnxflow/common/build.py
+++ b/src/onnxflow/common/build.py
@@ -246,7 +246,7 @@ class State:
 
     # Member variable that helps the code know if State has called
     # __post_init__ yet
-    after_post_init: bool = False
+    save_when_setting_attribute: bool = False
 
     # All of the following are critical aspects of the build,
     # including properties of the tool and choices made
@@ -280,18 +280,18 @@ class State:
         if self.model is not None and self.model_type != ModelType.UNKNOWN:
             self.model_hash = hash_model(self.model, self.model_type)
 
-        self.after_post_init = True
+        self.save_when_setting_attribute = True
 
     def __setattr__(self, name, val):
         super().__setattr__(name, val)
 
         # Always automatically save the state.yaml whenever State is modified
         # But don't bother saving until after __post_init__ is done (indicated
-        # by the after_post_init flag)
+        # by the save_when_setting_attribute flag)
         # Note: This only works when elements of the state are set directly.
         # When an element of state.info gets set, for example, state needs
         # to be explicitly saved by calling state.save().
-        if self.after_post_init and name != "after_post_init":
+        if self.save_when_setting_attribute and name != "save_when_setting_attribute":
             self.save()
 
     @property
@@ -343,7 +343,7 @@ class State:
             for key, value in vars(self).items()
             if not key == "inputs"
             and not key == "model"
-            and not key == "after_post_init"
+            and not key == "save_when_setting_attribute"
         }
 
         # Special case for saving objects

--- a/src/onnxflow/justbuildit/ignition.py
+++ b/src/onnxflow/justbuildit/ignition.py
@@ -395,7 +395,6 @@ def load_or_make_state(
                 )
 
                 printing.log_info(msg)
-                return state
             else:
                 cache_problems = cache_validation_func(
                     config=config,
@@ -422,9 +421,15 @@ def load_or_make_state(
                             "functionality or correctness). "
                         )
                         printing.log_warning(msg)
-                        return state
-                else:
-                    return state
+
+            # Ensure the model and inputs are part of the state
+            # This is useful  when loading models that still need to be built
+            if state.model is None:
+                state.model = model
+            if state.inputs is None:
+                state.inputs = inputs
+
+            return state
 
         else:
             # No state file found, so we have to build

--- a/src/onnxflow/justbuildit/ignition.py
+++ b/src/onnxflow/justbuildit/ignition.py
@@ -424,10 +424,12 @@ def load_or_make_state(
 
             # Ensure the model and inputs are part of the state
             # This is useful  when loading models that still need to be built
+            state.save_when_setting_attribute = False
             if state.model is None:
                 state.model = model
             if state.inputs is None:
                 state.inputs = inputs
+            state.save_when_setting_attribute = True
 
             return state
 

--- a/test/cli.py
+++ b/test/cli.py
@@ -775,21 +775,6 @@ class Testing(unittest.TestCase):
             with patch.object(sys, "argv", flatten(testargs)):
                 benchitcli()
 
-        # Benchmark with Onnx Runtime
-        testargs = [
-            "benchit",
-            "benchmark",
-            bash(f"{corpus_dir}/linear.py"),
-            "--cache-dir",
-            cache_dir,
-            "--device",
-            "x86",
-            "--runtime",
-            "ort",
-        ]
-        with patch.object(sys, "argv", flatten(testargs)):
-            benchitcli()
-
         # Benchmark with Pytorch
         testargs = [
             "benchit",
@@ -801,6 +786,21 @@ class Testing(unittest.TestCase):
             "x86",
             "--runtime",
             "torch-eager",
+        ]
+        with patch.object(sys, "argv", flatten(testargs)):
+            benchitcli()
+
+        # Benchmark with Onnx Runtime
+        testargs = [
+            "benchit",
+            "benchmark",
+            bash(f"{corpus_dir}/linear.py"),
+            "--cache-dir",
+            cache_dir,
+            "--device",
+            "x86",
+            "--runtime",
+            "ort",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             benchitcli()

--- a/test/cli.py
+++ b/test/cli.py
@@ -800,7 +800,7 @@ class Testing(unittest.TestCase):
             "--device",
             "x86",
             "--runtime",
-            "torch",
+            "torch-eager",
         ]
         with patch.object(sys, "argv", flatten(testargs)):
             benchitcli()


### PR DESCRIPTION
* Adds `--runtime` arg to benchit
* Changes the number of devices on a single CLI call to 1
* Adds Pytorch runtime
* Adds Pytorch 2.x compiled runtime
* Adds runtime version to mlagility_stats