### PR TITLE
Update diffusers version requirement

### DIFF
--- a/models/requirements.txt
+++ b/models/requirements.txt
@@ -11,7 +11,7 @@ torch_geometric>=2.3.0
 transformers>=4.21.0
 pytorch-pretrained-biggan>=0.1.1
 timm>=0.6.7
-diffusers>=0.2.4
+diffusers>=0.2.4, <=0.12
 requests
 Pillow
 nltk


### PR DESCRIPTION
Otherwise hits below error if diffusers >= 0.13
```
  File "/mla_bench/lib/python3.10/site-packages/diffusers/pipelines/pipeline_utils.py", line 63, in <module>
    from transformers.utils import SAFE_WEIGHTS_NAME as TRANSFORMERS_SAFE_WEIGHTS_NAME
ImportError: cannot import name 'SAFE_WEIGHTS_NAME' from 'transformers.utils' (/mla_bench/lib/python3.10/site-packages/transformers/utils/__init__.py)
```

Another option is to bump `transformers` version. I have not done that since it is currently limited to `4.22.1` by requirements from `detoxify`