### PR TITLE
Ensure that the spinner exists when parent process is terminated

### DIFF
--- a/src/onnxflow/justbuildit/stage.py
+++ b/src/onnxflow/justbuildit/stage.py
@@ -2,9 +2,9 @@ import abc
 import sys
 import time
 import os
-import psutil
 from typing import List, Tuple
 from multiprocessing import Process
+import psutil
 import onnxflow.common.printing as printing
 import onnxflow.common.exceptions as exp
 import onnxflow.common.build as build

--- a/src/onnxflow/justbuildit/stage.py
+++ b/src/onnxflow/justbuildit/stage.py
@@ -2,6 +2,7 @@ import abc
 import sys
 import time
 import os
+import psutil
 from typing import List, Tuple
 from multiprocessing import Process
 import onnxflow.common.printing as printing
@@ -10,7 +11,8 @@ import onnxflow.common.build as build
 
 
 def _spinner(message):
-    while True:
+    parent_pid = os.getppid()
+    while psutil.pid_exists(parent_pid):
         for cursor in ["   ", ".  ", ".. ", "..."]:
             time.sleep(0.5)
             status = f"      {message}{cursor}\r"


### PR DESCRIPTION
Closes https://github.com/groq/mlagility/issues/240

## Bug description

Spinner (child) processes might remain running even after the parent process is terminated (Orphan Process). 

## Reproducing

To reproduce the issue on a VM of any size open 3 terminal follow the steps below:

**Step 1:** Run `watch pgrep benchit` on terminal A.
**Step 2:** Run `benchit models/transformer/bert.py` on terminal B.
**Step 3:** Monitor the PIDs shown in terminal A. When a total of 2 PIDs are shown, run `kill -9 FIRST_PID`

This will kill the parent process and make the child process (spinner) an orphan. 

## This PR

This PR ensures that the spinner exists if parent process is terminated.

