### PR TITLE
Save the correct ONNX opset

### DIFF
--- a/src/mlagility/analysis/util.py
+++ b/src/mlagility/analysis/util.py
@@ -90,7 +90,7 @@ def populate_onnx_model_info(onnx_model) -> Dict:
     result_dict.update(
         {
             "ir_version": getattr(model, "ir_version", None),
-            "opset": getattr(model.opset_import[-1], "version", None),
+            "opset": getattr(model.opset_import[0], "version", None),
             "size on disk (KiB)": round(
                 model.SerializeToString().__sizeof__() / 1024, 4
             ),

--- a/test/cli.py
+++ b/test/cli.py
@@ -533,6 +533,12 @@ class Testing(unittest.TestCase):
                     "onnx_ops_counter"
                 ]
 
+                # Make sure the mlagility_stats has the expected ONNX opset
+                assert (
+                    stats_dict["onnx_model_information"]["opset"]
+                    == build.DEFAULT_ONNX_OPSET
+                ), stats_dict["onnx_model_information"]["opset"]
+
     def test_008_cli_version(self):
 
         # Get the version number


### PR DESCRIPTION
Closes #256 

## Implementation Justification

I could not find a durable to implement a solution because the ONNX `opset_import` object is a `List` (ie, there is no way to index into it in a way that guarantees you are getting the opset). 

So, we are using a magic number 😢 . I added a test so that we will find out if our magic number breaks.

## Demo

Before:
```
Info: The MLAgility stats for ~/.cache/mlagility/linear_selftest_d5b1df11/mlagility_stats.yaml are:
hash: d5b1df11
onnx_input_dimensions:
  x:
  - 10
onnx_model_information:
  ir_version: 8
  opset: 1

etc...
```

After:
```
Info: The MLAgility stats for ~/.cache/mlagility/linear_selftest_d5b1df11/mlagility_stats.yaml are:
hash: d5b1df11
onnx_input_dimensions:
  x:
  - 10
onnx_model_information:
  ir_version: 8
  opset: 14
```

ie, opset now correctly prints instead of always printing `1`.

