### PR TITLE
Fix ability to load from state when Groq device is selected

### DIFF
--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -171,8 +171,18 @@ def call_benchit(
             sys.stdout = sys.stdout.terminal
         status.update(tracer_args.models_found)
 
+        if tracer_args.device == "groq":
+            import groqflow.common.build as groq_build
+
+            state_type = groq_build.State
+        else:
+            state_type = build.State
+        state_type = build.State
+
         build_state = build.load_state(
-            cache_dir=tracer_args.cache_dir, build_name=build_name
+            cache_dir=tracer_args.cache_dir,
+            build_name=build_name,
+            state_type=state_type,
         )
 
         # ONNX stats that we want to save into the build's mlagility_stats.yaml file


### PR DESCRIPTION
**Issue:**

All Groq-related benchmarking fails when loading the State, which always happens on `analysis.py` in the `finally` block.


**Solution:**

Provide correct state type to load_state.

**To reproduce:**

Go to `mlagility/models/selftest` and run `benchit linear.py --build-only --device groq`.

Expected behavior without this fix: An onnxflow exception being raised (onnxflow.common.exceptions.StateError) 

Expected behavior with this fix: No onnxflow exceptions. You may still see a groqflow exception, depending on how it was installed in your system.
