### PR TITLE
Exit frame exploration if Python is shutting down

### DIFF
--- a/src/mlagility/analysis/analysis.py
+++ b/src/mlagility/analysis/analysis.py
@@ -295,6 +295,10 @@ def explore_frame(
     is called.
     """
 
+    # Exit frame exploration if Python is shutting down
+    if not bool(sys.modules):
+        return
+
     # Skip all variables that are not a subclass of torch.nn.Module/tf.keras.Model
     # Note: try block used since dead weakreferences fail when checking subclass
     try:


### PR DESCRIPTION
Closes https://github.com/groq/mlagility/issues/277

## Issue

Benchit crashes if target script calls `exit()`

## Reproducing

`benchit exit.py` where `exit.py` contains any script that eventually explicitly calls `exit()`

You should see something like:

```
Exception ignored in: <function WeakValueDictionary.__init__.<locals>.remove at 0x7f92b0043310>
Traceback (most recent call last):
  File "/net/home/dhnoronha/miniconda3/envs/mla/lib/python3.8/weakref.py", line 103, in remove
  File "/net/home/dhnoronha/mlagility/src/mlagility/analysis/analysis.py", line 472, in tracefunc
  File "/net/home/dhnoronha/mlagility/src/mlagility/analysis/analysis.py", line 309, in explore_frame
TypeError: 'NoneType' object is not callable
```

Note that this is not an exception being raised, but an exception being ignored during shutdown.

## Solution

Exit frame exploration if Python is shutting down.

## CI Testing

Given that this is not an exception being raised, but an exception being ignored during shutdown, `unittest` is not able to capture it. You can find more information about it [here](https://stackoverflow.com/questions/38036540/what-type-of-message-exception-ignored-in-is).
