### PR TITLE
Fix Python 3.10 CI failure by limiting protobuf version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "onnxruntime>=1.10.0",
         "paramiko==2.11.0",
         "torch>=1.12.1",
-        "protobuf>=3.17.3",
+        "protobuf>=3.17.3,<3.21",
         "pyyaml>=5.4",
         "typeguard>=2.3.13",
         "packaging>=21.3",


### PR DESCRIPTION
This PR has two commits.

* The first commits shows that CI fails for Python 3.10 even if no changes are made to the code
* The second commit fixes the issue by limiting the protobuf version