### PR TITLE
Avoid accepting gobbledegook inputs by correctly checking for file extensions

### DIFF
--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -94,8 +94,8 @@ def main():
     # Parser for the "benchmark" command
     #######################################
 
-    def check_extension(choices, file_name, parser):
-        _, extension = os.path.splitext(file_name)
+    def check_extension(choices, file_name):
+        _, extension = os.path.splitext(file_name.split("::")[0])
         if extension[1:].lower() not in choices:
             raise exceptions.ArgError(
                 f"input_files must end with .py or .onnx (got '{file_name}')"
@@ -111,7 +111,7 @@ def main():
         "input_files",
         nargs="+",
         help="One or more script (.py) or ONNX (.onnx) files to be benchmarked",
-        type=lambda file: check_extension(("py", "onnx"), file, benchmark_parser),
+        type=lambda file: check_extension(("py", "onnx"), file),
     )
 
     slurm_or_processes_group = benchmark_parser.add_mutually_exclusive_group()

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -93,6 +93,12 @@ def main():
     # Parser for the "benchmark" command
     #######################################
 
+    def check_extension(choices, file_name, parser):
+        extension = os.path.splitext(file_name)[1][1:]
+        if extension not in choices:
+            parser.error(f"input_files must end with .py or .onnx (got '{file_name}')")
+        return file_name
+
     benchmark_parser = subparsers.add_parser(
         "benchmark", help="Benchmark the performance of one or more models"
     )
@@ -102,6 +108,7 @@ def main():
         "input_files",
         nargs="+",
         help="One or more script (.py) or ONNX (.onnx) files to be benchmarked",
+        type=lambda file: check_extension(("py", "onnx"), file, benchmark_parser),
     )
 
     slurm_or_processes_group = benchmark_parser.add_mutually_exclusive_group()

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import sys
+from difflib import get_close_matches
 import onnxflow.common.build as build
 import onnxflow.common.exceptions as exceptions
 import mlagility.common.filesystem as filesystem
@@ -512,8 +513,25 @@ def main():
     # we alter argv to insert the command for them.
 
     if len(sys.argv) > 1:
-        if sys.argv[1] not in subparsers.choices.keys() and "-h" not in sys.argv[1]:
-            sys.argv.insert(1, "benchmark")
+        first_arg = sys.argv[1]
+        if first_arg not in subparsers.choices.keys() and "-h" not in first_arg:
+            if "." in first_arg:
+                sys.argv.insert(1, "benchmark")
+            else:
+                # Check how close we are from each of the valid options
+                valid_options = list(subparsers.choices.keys())
+                close_matches = get_close_matches(first_arg, valid_options)
+
+                error_msg = f"Unexpected positional argument `benchit {first_arg}`. "
+                if close_matches:
+                    error_msg += f"Did you mean `benchit {close_matches[0]}`?"
+                else:
+                    error_msg += (
+                        "The first positional argument must either be "
+                        "an input file with the .py or .onnx file extension or "
+                        f"one of the following commands: {valid_options}."
+                    )
+                raise exceptions.ArgError(error_msg)
 
     args = parser.parse_args()
     if args.func == benchmark_command:

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -94,8 +94,9 @@ def main():
     #######################################
 
     def check_extension(choices, file_name, parser):
-        extension = os.path.splitext(file_name)[1][1:]
-        if extension not in choices:
+        _, extension = os.path.splitext(file_name)
+        print(extension)
+        if extension[1:].lower() not in choices:
             parser.error(f"input_files must end with .py or .onnx (got '{file_name}')")
         return file_name
 

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -95,7 +95,6 @@ def main():
 
     def check_extension(choices, file_name, parser):
         _, extension = os.path.splitext(file_name)
-        print(extension)
         if extension[1:].lower() not in choices:
             parser.error(f"input_files must end with .py or .onnx (got '{file_name}')")
         return file_name

--- a/src/mlagility/cli/cli.py
+++ b/src/mlagility/cli/cli.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import sys
 import onnxflow.common.build as build
+import onnxflow.common.exceptions as exceptions
 import mlagility.common.filesystem as filesystem
 import mlagility.cli.report as report
 from mlagility.api.script_api import benchmark_files
@@ -96,7 +97,9 @@ def main():
     def check_extension(choices, file_name, parser):
         _, extension = os.path.splitext(file_name)
         if extension[1:].lower() not in choices:
-            parser.error(f"input_files must end with .py or .onnx (got '{file_name}')")
+            raise exceptions.ArgError(
+                f"input_files must end with .py or .onnx (got '{file_name}')"
+            )
         return file_name
 
     benchmark_parser = subparsers.add_parser(

--- a/test/cli.py
+++ b/test/cli.py
@@ -22,6 +22,7 @@ from mlagility.common import filesystem
 import mlagility.api.ortmodel as ortmodel
 import onnxflow.common.build as build
 import onnxflow.common.cache as cache
+import onnxflow.common.exceptions as exceptions
 
 
 # We generate a corpus on to the filesystem during the test
@@ -905,6 +906,13 @@ class Testing(unittest.TestCase):
         # Compile.py contains two Pytorch models.
         # One of those is compiled and should be skipped.
         assert builds_found == 1
+
+    def test_019_invalid_file_type(self):
+        # Ensure that we get an error when running benchit with invalid input_files
+        with self.assertRaises(exceptions.ArgError):
+            testargs = ["benchit", "awgawfaw"]
+            with patch.object(sys, "argv", flatten(testargs)):
+                benchitcli()
 
 
 if __name__ == "__main__":

--- a/test/cli.py
+++ b/test/cli.py
@@ -910,7 +910,7 @@ class Testing(unittest.TestCase):
     def test_019_invalid_file_type(self):
         # Ensure that we get an error when running benchit with invalid input_files
         with self.assertRaises(exceptions.ArgError):
-            testargs = ["benchit", "awgawfaw"]
+            testargs = ["benchit", "gobbledegook"]
             with patch.object(sys, "argv", flatten(testargs)):
                 benchitcli()
 


### PR DESCRIPTION
Closes https://github.com/groq/mlagility/issues/285

Examples:

```
(mla) dhnoronha@dhnoronha:/net/home/dhnoronha/mlagility$ benchit casch

Error: Unexpected positional argument `benchit casch`. Did you mean `benchit cache`?

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████
```

```
(mla) dhnoronha@dhnoronha:/net/home/dhnoronha/mlagility$ benchit gobbledegook

Error: Unexpected positional argument `benchit gobbledegook`. The first positional argument must either be an input file with the .py or .onnx file extension or one of the following commands: ['benchmark', 'cache', 'models', 'version'].

▄██████████████▄▐█▄▄▄▄█▌
██████▌▄▌▄▐▐▌███▌▀▀██▀▀
████▄█▌▄▌▄▐▐▌▀███▄▄█▌
▄▄▄▄▄██████████████
```