### PR TITLE
Azure self-hosted CI runner for GPU tests

### DIFF
--- a/.github/workflows/test_gpu_mlagility.yml
+++ b/.github/workflows/test_gpu_mlagility.yml
@@ -4,16 +4,18 @@
 name: Test MLAgility Using Self-Hosted Azure GPU
 
 on:
+  # Triggers the workflow when changes are pushed to the repository
   push:
     branches: ["main"]
-  pull_request:
-    branches: ["main"]
+  # Allows users to manually trigger the workflow using the GitHub UI
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   start_vm:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -24,6 +26,7 @@ jobs:
       - name: Turn on Azure VM
         run: |
           az login --username ${{ secrets.AZURE_CLIENT_ID }} --password ${{ secrets.AZURE_CLIENT_PWD }}
+          az vm wait --name morecuda --resource-group morecuda_group --custom "instanceView.statuses[?code=='PowerState/deallocated']" --interval 30
           az vm start --name morecuda --resource-group morecuda_group
           az vm wait --created --name morecuda --resource-group morecuda_group
           az vm run-command invoke --name morecuda --resource-group morecuda_group --command-id RunShellScript --scripts 'export RUNNER_ALLOW_RUNASROOT="1" && export HOME="/home/azureuser" && bash /home/azureuser/actions-runner/run.sh &'

--- a/.github/workflows/test_gpu_mlagility.yml
+++ b/.github/workflows/test_gpu_mlagility.yml
@@ -1,0 +1,87 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Test MLAgility Using Self-Hosted Azure GPU
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  start_vm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install az cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y azure-cli
+      - name: Turn on Azure VM
+        run: |
+          az login --username ${{ secrets.AZURE_CLIENT_ID }} --password ${{ secrets.AZURE_CLIENT_PWD }}
+          az vm start --name morecuda --resource-group morecuda_group
+          az vm wait --created --name morecuda --resource-group morecuda_group
+          az vm run-command invoke --name morecuda --resource-group morecuda_group --command-id RunShellScript --scripts 'export RUNNER_ALLOW_RUNASROOT="1" && export HOME="/home/azureuser" && bash /home/azureuser/actions-runner/run.sh &'
+  build_and_test:
+    needs: start_vm
+    timeout-minutes: 10
+    if: ${{ needs.start_vm.result == 'success' }}
+    runs-on: self-hosted
+    env:
+      MLAGILITY_DEBUG: True
+      MLAGILITY_TRACEBACK: True
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          activate-environment: mla
+          python-version: ${{ matrix.python-version }}
+      - name: Install Docker
+        shell: bash -el {0}
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
+          sudo chmod a+r /etc/apt/keyrings/docker.gpg
+          echo \
+          "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+          "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          sudo chmod 666 /var/run/docker.sock
+      - name: Install dependencies
+        shell: bash -el {0}
+        run: |
+          python -m pip install --upgrade pip
+          conda install pylint
+          if [ -f setup.py ]; then pip install -e .; fi
+          pip install transformers
+          python -m pip check
+      - name: Test with unittest
+        shell: bash -el {0}
+        run: |
+          # E2E tests
+          rm -rf ~/.cache/mlagility
+          python test/gpu.py
+  deallocate_vm:
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install az cli
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y azure-cli
+      - name: Deallocate Azure VM
+        run: |
+          az login --username ${{ secrets.AZURE_CLIENT_ID }} --password ${{ secrets.AZURE_CLIENT_PWD }}
+          az vm deallocate --name morecuda --resource-group morecuda_group

--- a/.github/workflows/test_gpu_mlagility.yml
+++ b/.github/workflows/test_gpu_mlagility.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
-name: Test MLAgility Using Self-Hosted Azure GPU
+name: Test MLAgility on Azure GPUs
 
 on:
   # Triggers the workflow when changes are pushed to the repository

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![MLAgility tests](https://github.com/groq/mlagility/actions/workflows/test_mlagility.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")
 [![onnxflow tests](https://github.com/groq/mlagility/actions/workflows/test_onnxflow.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")
 [![MLAgility GPU tests](https://github.com/groq/mlagility/actions/workflows/test_gpu_mlagility.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")
-
 [![OS - Linux](https://img.shields.io/badge/OS-Linux-blue?logo=linux&logoColor=white)](https://github.com/groq/mlagility/blob/main/docs/install.md "Check out our instructions")
 [![Made with Python](https://img.shields.io/badge/Python-3.8,3.10-blue?logo=python&logoColor=white)](https://github.com/groq/mlagility/blob/main/docs/install.md "Check out our instructions")
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://github.com/groq/mlagility/blob/main/LICENSE "Check out our license")

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![MLAgility tests](https://github.com/groq/mlagility/actions/workflows/test_mlagility.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")
 [![onnxflow tests](https://github.com/groq/mlagility/actions/workflows/test_onnxflow.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")
+[![MLAgility GPU tests](https://github.com/groq/mlagility/actions/workflows/test_gpu_mlagility.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")
+
 [![OS - Linux](https://img.shields.io/badge/OS-Linux-blue?logo=linux&logoColor=white)](https://github.com/groq/mlagility/blob/main/docs/install.md "Check out our instructions")
 [![Made with Python](https://img.shields.io/badge/Python-3.8,3.10-blue?logo=python&logoColor=white)](https://github.com/groq/mlagility/blob/main/docs/install.md "Check out our instructions")
 [![License](https://img.shields.io/badge/License-MIT-blue)](https://github.com/groq/mlagility/blob/main/LICENSE "Check out our license")

--- a/test/gpu.py
+++ b/test/gpu.py
@@ -1,0 +1,99 @@
+"""
+MLAgility GPU tests
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+import sys
+from pathlib import Path
+import shutil
+import yaml
+from mlagility.cli.cli import main as benchitcli
+import onnxflow.common.build as build
+import onnxflow.common.cache as cache
+from cli import assert_success_of_builds, flatten, bash, strip_dot_py
+
+# We generate a corpus on to the filesystem during the test
+# to get around how weird bake tests are when it comes to
+# filesystem access
+
+test_scripts_dot_py = {
+    "linear.py": """# labels: name::linear author::benchit license::mit test_group::a
+import torch
+
+torch.manual_seed(0)
+
+
+class LinearTestModel(torch.nn.Module):
+    def __init__(self, input_features, output_features):
+        super(LinearTestModel, self).__init__()
+        self.fc = torch.nn.Linear(input_features, output_features)
+
+    def forward(self, x):
+        output = self.fc(x)
+        return output
+
+
+input_features = 10
+output_features = 10
+
+# Model and input configurations
+model = LinearTestModel(input_features, output_features)
+inputs = {"x": torch.rand(input_features)}
+
+output = model(**inputs)
+
+"""
+}
+
+
+# Create a test directory and make it the CWD
+test_dir = "cli_test_dir"
+cache_dir_name = "cache-dir"
+cache_dir = os.path.abspath(cache_dir_name)
+dirpath = Path(test_dir)
+if dirpath.is_dir():
+    shutil.rmtree(dirpath)
+os.makedirs(test_dir)
+os.chdir(test_dir)
+
+corpus_dir = os.path.join(os.getcwd(), "test_corpus")
+extras_dir = os.path.join(corpus_dir, "extras")
+os.makedirs(extras_dir, exist_ok=True)
+
+for key, value in test_scripts_dot_py.items():
+    model_path = os.path.join(corpus_dir, key)
+
+    with open(model_path, "w", encoding="utf") as f:
+        f.write(value)
+
+
+class Testing(unittest.TestCase):
+    def setUp(self) -> None:
+        cache.rmdir(cache_dir)
+
+        return super().setUp()
+
+    def test_basic(self):
+        test_script = "linear.py"
+        # Benchmark with Pytorch
+        testargs = [
+            "benchit",
+            "benchmark",
+            os.path.join(corpus_dir, test_script),
+            "--cache-dir",
+            cache_dir,
+            "--device",
+            "nvidia",
+        ]
+        with patch.object(sys, "argv", flatten(testargs)):
+            benchitcli()
+
+        assert_success_of_builds(
+            [test_script], cache_dir, check_perf=True, runtime="trt"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/gpu.py
+++ b/test/gpu.py
@@ -14,10 +14,6 @@ import onnxflow.common.build as build
 import onnxflow.common.cache as cache
 from cli import assert_success_of_builds, flatten, bash, strip_dot_py
 
-# We generate a corpus on to the filesystem during the test
-# to get around how weird bake tests are when it comes to
-# filesystem access
-
 test_scripts_dot_py = {
     "linear.py": """# labels: name::linear author::benchit license::mit test_group::a
 import torch


### PR DESCRIPTION
Closes https://github.com/groq/mlagility/issues/26

# Overview

This PR adds a self-hosted CI runner for MLAgility GPU tests. The VM used is powered by Azure. 

# Good to understand before reviewing

## How often does this workflow runs? 📅

It runs every time a PR is merged into main. You can also trigger it manually using the GitHub cli: `gh workflow run 'Test MLAgility Using Self-Hosted Azure GPU' --ref azure_gpu_ci`. You can see also see the results as part of the [actions page](https://github.com/groq/mlagility/actions/workflows/test_gpu_mlagility.yml).

## How fast is it? ⏱️

Around 8m 20s. You can find more details about it [here](https://github.com/groq/mlagility/actions/workflows/test_gpu_mlagility.yml).

## What happens if the GPU test fails? 💀

The badge on `README.md` indicates when this test fails: [![MLAgility GPU tests](https://github.com/groq/mlagility/actions/workflows/test_gpu_mlagility.yml/badge.svg)](https://github.com/groq/mlagility/tree/main/test "Check out our tests")


The workflow **should** also always turn off the Azure VM (even if the test fails).

## What happens if we try to run multiple of those workflows simultaneously? 🦺

This workflow only starts once the VM has been turned off by the previous workflow. As a result, collisions will only happen if multiple workflows are launched simultaneously. This is unlikely since multiple PRs can't merge simultaneously.

Although very unlikely, issues might still occur if 3 or more PRs merge within a very small time frame (e.g. Workflow A is running, workflows B, and C are waiting and might try to start at the same time). Note that this is only possible if the GPU workflow takes significantly longer than our traditional CI that needs to run between merges.