### PR TITLE
Pass arbitrary benchit args into Azure CLI

### DIFF
--- a/src/mlagility/cli/cloud/control.py
+++ b/src/mlagility/cli/cloud/control.py
@@ -888,13 +888,15 @@ class Cluster(Device):
     def wipe_mlagility_cache(self):
         self.parallelize(super().wipe_mlagility_cache)
 
-    def run(self, input_files: str):
+    def run(self, input_files: str, benchit_args: str = ""):
         # TODO: create more jobs based on permutations such as
         # batch size, data type, etc.
         device_type = hardware_to_device[self.hardware]
 
         jobs = [
-            benchit_prefix(f"mlagility{input[2:]} --lean-cache --device {device_type}")
+            benchit_prefix(
+                f"mlagility{input.split('mlagility')[1]} --lean-cache --device {device_type} {benchit_args}"
+            )
             for input in input_files
         ]
 
@@ -1049,8 +1051,16 @@ def main():
     parser.add_argument(
         "--input-files",
         "-f",
-        help="Path to input files for job",
+        help="Path to input files for job. Must be an absolute path that includes a "
+        "clone of mlagility (e.g., /home/jfowers/mlagility/models/selftest/*.py)",
         nargs="*",
+    )
+
+    parser.add_argument(
+        "--benchit-args",
+        "-a",
+        help="Arguments to pass to benchit while running a job",
+        default="",
     )
 
     # Parse the arguments
@@ -1097,7 +1107,7 @@ def main():
 
     for command in args.commands:
         if command == "run":
-            handle.run(args.input_files)
+            handle.run(args.input_files, args.benchit_args)
         else:
             command_to_function[command]()
 


### PR DESCRIPTION
Closes #302 

Also fixes a minor bug with file paths for the `run` command.

Demo:

```
(azure) jfowers@jfowers:~/mlagility/src/mlagility/cli/cloud$ python control.py run --cluster --name argtest --size 2 -f /home/jfowers/mlagility/models/selftest/*.py -a="--build-only"
```

The resulting CSV file has the build information (e.g., export success) but no benchmarking information (e.g., latency measurement)

```
model_name,author,model_class,params,hash,license,task,groq_chips_used,groq_estimated_latency,nvidia_latency,x86_latency,onnx_exported,onnx_optimized,onnx_converted
twolayer,selftest,TwoLayerTestModel,85,676c7c6d,-,-,-,-,-,-,True,True,True
linear,selftest,LinearTestModel,110,d5b1df11,-,-,-,-,-,-,True,True,True
```